### PR TITLE
Fix Maven Central publishing configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,12 +52,12 @@ jobs:
       - name: Publish to Maven Central
         if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :phosphor-core:publishAllPublicationsToMavenCentral
+        run: ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}

--- a/phosphor-core/build.gradle.kts
+++ b/phosphor-core/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint")
     id("org.jetbrains.dokka")
     id("com.vanniktech.maven.publish")
-    id("signing")
 }
 
 val phosphorVersion: String by project
@@ -59,10 +58,6 @@ kotlin {
             }
         }
     }
-}
-
-signing {
-    useGpgCmd()
 }
 
 mavenPublishing {


### PR DESCRIPTION
## Summary
- Removed duplicate `signing` plugin and `useGpgCmd()` configuration that conflicted with vanniktech plugin's in-memory signing
- Updated GitHub Actions workflow to use correct Maven Central Portal secret names (`MAVEN_CENTRAL_USERNAME/PASSWORD` instead of `OSSRH_USERNAME/PASSWORD`)
- Fixed Gradle task name from `publishAllPublicationsToMavenCentral` to `publishAllPublicationsToMavenCentralRepository`

These changes align the publishing configuration with the vanniktech maven-publish plugin's expected setup, which uses in-memory signing on CI (no GPG agent available).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>