### PR TITLE
Fix Maven Central publishing: decode base64-encoded signing key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,15 +49,22 @@ jobs:
       - name: Run tests before publish
         run: ./gradlew :phosphor-core:jvmTest
 
+      - name: Decode signing key
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY }}
+        run: echo "$SIGNING_KEY_BASE64" | base64 -d > /tmp/signing-key.asc
+
       - name: Publish to Maven Central
         if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository
+        run: |
+          export ORG_GRADLE_PROJECT_signingInMemoryKey="$(cat /tmp/signing-key.asc)"
+          ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}


### PR DESCRIPTION
## Summary

The vanniktech maven-publish plugin expects raw ASCII-armored PGP key material, but the `SIGNING_KEY` GitHub secret is base64-encoded. This causes signing to fail during publish workflows.

Add a decode step that converts the base64-encoded secret to plain text before passing it to the plugin via the `ORG_GRADLE_PROJECT_signingInMemoryKey` environment variable.

## Changes

- Added "Decode signing key" workflow step that base64-decodes the signing key secret
- Updated the "Publish to Maven Central" step to use the decoded key from `/tmp/signing-key.asc`
- Removed the direct reference to the base64-encoded `SIGNING_KEY` secret from the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)