### PR TITLE
Update phosphorVersion to 0.2.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ kotlin.version=2.1.20
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 #Phosphor
-phosphorVersion=0.1.0
+phosphorVersion=0.2.2


### PR DESCRIPTION
## Summary
Updates `gradle.properties` to set `phosphorVersion=0.2.2`, aligning it with the `v0.2.2` tag. This fixes the version validation in the publish workflow that was failing with: "Tag version (0.2.2) does not match gradle.properties (0.1.0)".

## Test plan
- [x] Version now matches between tag and gradle.properties
- [x] Publish workflow version validation will pass when triggered with v0.2.2 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)