### PR TITLE
Add emitter metadata channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the dependency:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("link.socket:phosphor-core:0.2.2")
+    implementation("link.socket:phosphor-core:0.3.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ Phase transitions trigger effects automatically — spark bursts, substrate ripp
 
 ---
 
+## Metadata-Driven Emitters
+
+Emitter instances can carry generic scalar metadata that effects consume at render time.
+
+```kotlin
+emitters.emit(
+    effect = EmitterEffect.SparkBurst(),
+    position = Vector3.ZERO,
+    metadata = mapOf(
+        MetadataKeys.INTENSITY to 1.4f,
+        MetadataKeys.HEAT to 0.85f,
+    ),
+)
+```
+
+`SparkBurst` uses these values to scale brightness and expansion while preserving the same base effect shape. See [docs/METADATA_GUIDE.md](docs/METADATA_GUIDE.md) for the built-in keys and integration pattern.
+
+---
+
 ## Platforms
 
 Phosphor compiles to:

--- a/docs/METADATA_GUIDE.md
+++ b/docs/METADATA_GUIDE.md
@@ -1,0 +1,50 @@
+# Metadata-Driven Emitters
+
+Phosphor emitters can now carry per-instance scalar metadata. This lets an excitation source keep the effect shape stable while varying the metabolic weight of each trigger.
+
+## Overview
+
+`EmitterManager.emit(...)` accepts a `metadata: Map<String, Float>` argument. The map is stored on the live `EmitterInstance` and passed into `EmitterEffect.influence(...)` on every query.
+
+When metadata is absent, effects keep their legacy behavior.
+
+## Built-in Keys
+
+- `MetadataKeys.INTENSITY`: scales an effect's peak output.
+- `MetadataKeys.HEAT`: biases effects toward hotter, more energetic behavior.
+- `MetadataKeys.DENSITY`: reserved for effects that vary particle or fragment density.
+- `MetadataKeys.DURATION_SCALE`: stretches or compresses effect lifetime.
+- `MetadataKeys.RADIUS_SCALE`: widens or narrows spatial reach.
+
+## Example
+
+```kotlin
+val emitters = EmitterManager()
+
+emitters.emit(
+    effect = EmitterEffect.SparkBurst(),
+    position = Vector3.ZERO,
+    metadata = mapOf(
+        MetadataKeys.INTENSITY to 1.6f,
+        MetadataKeys.HEAT to 0.9f,
+        MetadataKeys.RADIUS_SCALE to 1.25f,
+    ),
+)
+```
+
+## Built-in Behavior
+
+`EmitterEffect.SparkBurst` consumes metadata today:
+
+- `INTENSITY` scales ring brightness.
+- `HEAT` increases outward expansion speed.
+- `DURATION_SCALE` stretches the burst lifetime.
+- `RADIUS_SCALE` widens the area of influence.
+
+Other built-in effects ignore metadata for now and remain behaviorally identical to earlier releases.
+
+## Guidance For Consumers
+
+- Keep keys generic. Map domain values onto visual semantics before they enter Phosphor.
+- Prefer normalized floats where practical so effect tuning stays stable across inputs.
+- Reuse `emptyMap()` when you have no metadata to avoid unnecessary allocations.

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ kotlin.version=2.3.10
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 #Phosphor
-phosphorVersion=0.2.3
+phosphorVersion=0.3.0

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/emitter/EmitterManager.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/emitter/EmitterManager.kt
@@ -9,9 +9,10 @@ data class EmitterInstance(
     val effect: EmitterEffect,
     val position: Vector3,
     val activatedAt: Float,
+    val metadata: Map<String, Float> = emptyMap(),
     val age: Float = 0f,
 ) {
-    val isExpired: Boolean get() = age >= effect.duration
+    val isExpired: Boolean get() = age >= effect.activeDuration(metadata)
 }
 
 /**
@@ -42,12 +43,14 @@ class EmitterManager {
         effect: EmitterEffect,
         position: Vector3,
         currentTime: Float = 0f,
+        metadata: Map<String, Float> = emptyMap(),
     ) {
         _instances.add(
             EmitterInstance(
                 effect = effect,
                 position = position,
                 activatedAt = currentTime,
+                metadata = metadata,
             ),
         )
     }
@@ -91,7 +94,7 @@ class EmitterManager {
             val dx = worldX - instance.position.x
             val dz = worldZ - instance.position.z
             val distance = kotlin.math.sqrt(dx * dx + dz * dz)
-            val influence = instance.effect.influence(distance, instance.age)
+            val influence = instance.effect.influence(distance, instance.age, instance.metadata)
             if (influence.intensity > 0f) {
                 result = result + influence
             }

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/emitter/MetadataKeys.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/emitter/MetadataKeys.kt
@@ -1,0 +1,24 @@
+package link.socket.phosphor.emitter
+
+/**
+ * Well-known metadata keys for generic emitter modulation.
+ *
+ * These remain domain-neutral so bridges can map their own numeric signals
+ * onto common visual semantics without leaking source concepts into Phosphor.
+ */
+object MetadataKeys {
+    /** Overall intensity multiplier. Scales an effect's peak intensity. */
+    const val INTENSITY = "phosphor.intensity"
+
+    /** Thermal energy. Higher values can bias effects toward hotter, brighter behavior. */
+    const val HEAT = "phosphor.heat"
+
+    /** Density multiplier for effects that vary their particle or fragment count. */
+    const val DENSITY = "phosphor.density"
+
+    /** Duration multiplier for effects that stretch or compress their lifespan. */
+    const val DURATION_SCALE = "phosphor.duration_scale"
+
+    /** Radius multiplier for effects that widen or tighten spatial reach. */
+    const val RADIUS_SCALE = "phosphor.radius_scale"
+}

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/emitter/EmitterEffectTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/emitter/EmitterEffectTest.kt
@@ -69,6 +69,50 @@ class EmitterEffectTest {
         }
     }
 
+    @Test
+    fun `SparkBurst metadata intensity can suppress influence`() {
+        val burst = EmitterEffect.SparkBurst()
+        val ringPos = burst.expansionSpeed * 0.05f
+        val influence =
+            burst.influence(
+                distanceFromCenter = ringPos,
+                timeSinceActivation = 0.05f,
+                metadata = mapOf(MetadataKeys.INTENSITY to 0f),
+            )
+        assertEquals(0f, influence.intensity)
+    }
+
+    @Test
+    fun `SparkBurst higher heat pushes the ring outward faster`() {
+        val burst = EmitterEffect.SparkBurst()
+        val lowHeat =
+            burst.influence(
+                distanceFromCenter = 1.1f,
+                timeSinceActivation = 0.1f,
+                metadata = mapOf(MetadataKeys.HEAT to 0.1f),
+            )
+        val highHeat =
+            burst.influence(
+                distanceFromCenter = 1.1f,
+                timeSinceActivation = 0.1f,
+                metadata = mapOf(MetadataKeys.HEAT to 0.9f),
+            )
+        assertTrue(highHeat.intensity > lowHeat.intensity)
+    }
+
+    @Test
+    fun `SparkBurst empty metadata preserves legacy behavior`() {
+        val burst = EmitterEffect.SparkBurst()
+        val legacy = burst.influence(distanceFromCenter = 0.4f, timeSinceActivation = 0.05f)
+        val metadataAware =
+            burst.influence(
+                distanceFromCenter = 0.4f,
+                timeSinceActivation = 0.05f,
+                metadata = emptyMap(),
+            )
+        assertEquals(legacy, metadataAware)
+    }
+
     // --- HeightPulse ---
 
     @Test


### PR DESCRIPTION
## Summary
- add per-instance metadata and generic metadata keys to emitter instances
- add metadata-aware lifetime and influence hooks, with SparkBurst consuming intensity, heat, radius, and duration metadata
- document the metadata API and cover propagation plus backward compatibility with emitter tests

## Testing
- ./gradlew ktlintFormat
- ./gradlew jvmTest