### PR TITLE
[codex] Establish phosphor-lumos module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run tests
-        run: ./gradlew :phosphor-core:jvmTest
+      - name: Run JVM tests
+        run: ./gradlew :phosphor-core:jvmTest :phosphor-lumos:jvmTest
 
       - name: Check formatting
-        run: ./gradlew :phosphor-core:ktlintCheck
+        run: ./gradlew :phosphor-core:ktlintCheck :phosphor-lumos:ktlintCheck
 
   ios_compile:
     name: iOS Compile
@@ -54,8 +54,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Compile iOS target
-        run: ./gradlew :phosphor-core:compileKotlinIosArm64
+      - name: Compile iOS targets
+        run: ./gradlew :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64
 
   test:
     name: Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run tests before publish
-        run: ./gradlew :phosphor-core:jvmTest :phosphor-core:compileKotlinIosArm64
+        run: ./gradlew :phosphor-core:jvmTest :phosphor-lumos:jvmTest :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64
 
       - name: Decode signing key
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -64,13 +64,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey="$(cat /tmp/signing-key.asc)"
-          ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository
+          ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository :phosphor-lumos:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           echo "Dry run mode - publishing to Maven Local only"
-          ./gradlew :phosphor-core:publishToMavenLocal
+          ./gradlew :phosphor-core:publishToMavenLocal :phosphor-lumos:publishToMavenLocal
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Phosphor is a Kotlin Multiplatform rendering library that translates cognitive state into visible light — ASCII luminance, color ramps, particle physics, and 3D waveform surfaces. Read [SOUL.md](SOUL.md) for project philosophy and values.
+Phosphor is a Kotlin Multiplatform rendering library that translates cognitive state into visible light — ASCII luminance, color ramps, particle physics, 3D waveform surfaces, and the Lumos voxel-orb companion visualization. Read [SOUL.md](SOUL.md) for project philosophy and values.
 
 ## Development Commands
 
@@ -18,12 +18,6 @@ Phosphor is a Kotlin Multiplatform rendering library that translates cognitive s
 ./gradlew ktlintFormat                 # Auto-format code
 ./gradlew ktlintCheck                  # Check formatting
 ./gradlew dokkaHtml                    # Generate API documentation
-```
-
-### Demo
-```bash
-./gradlew :phosphor-demo:run           # Run the desktop demo application
-./gradlew :phosphor-demo-cli:installDist && ./phosphor-demo-cli/phosphor-demo  # Run the terminal demo
 ```
 
 ### Publishing
@@ -45,13 +39,22 @@ Phosphor is a layered rendering pipeline: cognitive signals flow in, visible cha
 | Emitter | `emitter/` | EmitterEffect sealed hierarchy — transient visual events (SparkBurst, HeightPulse, Turbulence, ColorWash) |
 | Bridge | `bridge/` | Adapters connecting live runtime state to the animation field |
 
-### Rendering Surface Adapters (separate modules)
+### Active Modules
+
+| Module | Purpose |
+|--------|---------|
+| `phosphor-core/` | Shared rendering pipeline — signals, fields, palettes, cells, choreography, emitters, and runtime bridges |
+| `phosphor-lumos/` | Framework-free voxel-orb companion visualization for cognitive state, built as a sibling output module over `phosphor-core` |
+
+### Future / Aspirational Modules
 
 | Module | Purpose |
 |--------|---------|
 | `phosphor-mosaic/` | Mosaic (Compose-for-terminal) adapter — AnnotatedString output |
 | `phosphor-compose/` | Compose Multiplatform Canvas adapter — DrawScope rendering |
 | `phosphor-ansi/` | Raw ANSI escape code output for non-Compose terminals |
+| `phosphor-demo/` | Desktop demo app (Compose Desktop) |
+| `phosphor-demo-cli/` | Terminal demo app |
 
 ## Key Paths
 
@@ -59,10 +62,8 @@ Phosphor is a layered rendering pipeline: cognitive signals flow in, visible cha
 |--------|---------|
 | `phosphor-core/src/commonMain/` | Shared rendering pipeline — signals, fields, palettes, cells |
 | `phosphor-core/src/commonTest/` | Unit tests for palette mapping, projection math, particle physics |
-| `phosphor-mosaic/src/jvmMain/` | Terminal rendering via Mosaic AnnotatedString |
-| `phosphor-compose/src/commonMain/` | Compose Canvas rendering via DrawScope |
-| `phosphor-demo/` | Desktop demo app (Compose Desktop) |
-| `phosphor-demo-cli/` | Terminal demo app |
+| `phosphor-lumos/src/commonMain/` | Lumos module boundary for framework-free voxel-orb visualization data |
+| `phosphor-lumos/src/commonTest/` | Lumos smoke tests and future voxel-frame API tests |
 
 ## Before You Change Anything
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Phosphor is a Kotlin Multiplatform rendering library that transduces cognitive s
 
 Just as CRT phosphor converts electron energy into visible light, this library converts an AI agent's internal state into something you can see: sparse floating dots coalescing into dense bright strokes as cognition shifts from perception to execution.
 
+Phosphor ships `:phosphor-core` alongside `:phosphor-lumos`, its first separate output module. Lumos is a framework-free voxel-orb companion visualization for cognitive state; it complements the CRT-phosphor terminal aesthetic and does not replace it.
+
 ---
 
 ## The Pipeline
@@ -34,7 +36,14 @@ Signal → Field → Palette → Render → Choreography → Emitter → Surface
 | **Emitter** | `emitter/` | Transient effects — spark bursts, height pulses, turbulence — that decay naturally |
 | **Bridge** | `bridge/` | Connects runtime cognitive state to the animation field |
 
-`phosphor-core` has zero UI framework dependencies. Surface adapters (phosphor-mosaic, phosphor-compose, phosphor-ansi) live in separate modules.
+`phosphor-core` has zero UI framework dependencies. Platform-specific rendering belongs in separate surface modules; `:phosphor-lumos` is the first concrete sibling module and establishes the boundary for framework-free voxel-orb frame data.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `:phosphor-core` | Shared rendering pipeline — signals, fields, palettes, cells, choreography, emitters, and runtime bridges |
+| `:phosphor-lumos` | Voxel-orb companion visualization module for cognitive state, scaffolded for downstream Lumos frame APIs |
 
 ---
 

--- a/phosphor-lumos/build.gradle.kts
+++ b/phosphor-lumos/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 
     iosTargets.forEach {
         it.binaries.framework {
-            baseName = "phosphor-core"
+            baseName = "phosphor-lumos"
             xcf.add(this)
         }
     }
@@ -71,15 +71,12 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3")
+                implementation(project(":phosphor-core"))
             }
         }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
             }
         }
     }
@@ -91,14 +88,13 @@ mavenPublishing {
 
     configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
 
-    coordinates("link.socket", "phosphor-core", version.toString())
+    coordinates("link.socket", "phosphor-lumos", version.toString())
 
     pom {
-        name.set("Phosphor")
+        name.set("Phosphor Lumos")
         description.set(
-            "Kotlin Multiplatform rendering library that translates cognitive state " +
-                "into visible light — ASCII luminance, color ramps, particle physics, " +
-                "and 3D waveform surfaces.",
+            "Kotlin Multiplatform voxel-orb companion visualization for cognitive state, " +
+                "built on the Phosphor core signal and rendering substrate.",
         )
         url.set("https://github.com/socket-link/phosphor")
         inceptionYear.set("2025")

--- a/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/Lumos.kt
+++ b/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/Lumos.kt
@@ -1,0 +1,8 @@
+@file:Suppress("ktlint:standard:no-empty-file")
+
+/**
+ * Lumos provides framework-free voxel-orb visualization data for cognitive state,
+ * complementing Phosphor's CRT-terminal rendering pipeline without replacing it.
+ */
+
+package link.socket.phosphor.lumos

--- a/phosphor-lumos/src/commonTest/kotlin/link/socket/phosphor/lumos/LumosSmokeTest.kt
+++ b/phosphor-lumos/src/commonTest/kotlin/link/socket/phosphor/lumos/LumosSmokeTest.kt
@@ -1,0 +1,12 @@
+package link.socket.phosphor.lumos
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import link.socket.phosphor.signal.CognitivePhase
+
+class LumosSmokeTest {
+    @Test
+    fun `lumos package compiles with core dependency`() {
+        assertEquals(CognitivePhase.NONE, CognitivePhase.valueOf("NONE"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "Phosphor"
 
 include(":phosphor-core")
+include(":phosphor-lumos")
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
Adds `:phosphor-lumos` as a KMP sibling of `:phosphor-core`, with matching targets, a core implementation dependency, placeholder package KDoc, a smoke test, and Maven publishing.

Reconciles README/AGENTS and GitHub workflows so Lumos is treated as active while non-existent adapters/demos are marked future/aspirational.

Adjusts publishing scripts so `publishToMavenLocal` can run without local signing credentials while release signing remains credential-gated.

Validation: `./gradlew ktlintFormat`, `./gradlew projects`, `./gradlew jvmTest`, `./gradlew :phosphor-lumos:build :phosphor-lumos:allTests`, `./gradlew :phosphor-core:publishToMavenLocal :phosphor-lumos:publishToMavenLocal`, `git diff --check`; `./gradlew build` and `./gradlew allTests` still fail on the known PHO-19 JS browser precision assertion in `SimulationFrameTest`.