### PR TITLE
[codex] PHO-21/#41 add Lumos CLI terminal frame DTO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run JVM tests
-        run: ./gradlew jvmTest
+        run: ./gradlew :phosphor-core:jvmTest :phosphor-lumos:jvmTest :phosphor-lumos-cli:jvmTest
 
       - name: Verify formatting
         run: ./gradlew ktlintFormat --no-rebuild
@@ -87,7 +87,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run build
-        run: ./gradlew build
+        run: ./gradlew :phosphor-core:build :phosphor-lumos:build :phosphor-lumos-cli:build
 
       - name: Run all tests
         run: ./gradlew allTests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run tests before publish
-        run: ./gradlew :phosphor-core:jvmTest :phosphor-lumos:jvmTest :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64
+        run: ./gradlew :phosphor-core:jvmTest :phosphor-lumos:jvmTest :phosphor-lumos-cli:jvmTest :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64
 
       - name: Decode signing key
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -64,13 +64,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey="$(cat /tmp/signing-key.asc)"
-          ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository :phosphor-lumos:publishAllPublicationsToMavenCentralRepository
+          ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository :phosphor-lumos:publishAllPublicationsToMavenCentralRepository :phosphor-lumos-cli:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           echo "Dry run mode - publishing to Maven Local only"
-          ./gradlew :phosphor-core:publishToMavenLocal :phosphor-lumos:publishToMavenLocal
+          ./gradlew :phosphor-core:publishToMavenLocal :phosphor-lumos:publishToMavenLocal :phosphor-lumos-cli:publishToMavenLocal
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Phosphor is a layered rendering pipeline: cognitive signals flow in, visible cha
 |--------|---------|
 | `phosphor-core/` | Shared rendering pipeline — signals, fields, palettes, cells, choreography, emitters, and runtime bridges |
 | `phosphor-lumos/` | Framework-free voxel-orb companion visualization for cognitive state, built as a sibling output module over `phosphor-core` |
+| `phosphor-lumos-cli/` | JVM terminal DTO and future CLI renderer surface for projected Lumos voxel frames |
 
 ### Future / Aspirational Modules
 
@@ -64,6 +65,8 @@ Phosphor is a layered rendering pipeline: cognitive signals flow in, visible cha
 | `phosphor-core/src/commonTest/` | Unit tests for palette mapping, projection math, particle physics |
 | `phosphor-lumos/src/commonMain/` | Lumos module boundary for framework-free voxel-orb visualization data |
 | `phosphor-lumos/src/commonTest/` | Lumos smoke tests and future voxel-frame API tests |
+| `phosphor-lumos-cli/src/commonMain/` | JVM CLI-facing Lumos terminal frame DTOs |
+| `phosphor-lumos-cli/src/commonTest/` | CLI DTO serialization and shape-contract tests |
 
 ## Before You Change Anything
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Phosphor is a Kotlin Multiplatform rendering library that transduces cognitive s
 
 Just as CRT phosphor converts electron energy into visible light, this library converts an AI agent's internal state into something you can see: sparse floating dots coalescing into dense bright strokes as cognition shifts from perception to execution.
 
-Phosphor ships `:phosphor-core` alongside `:phosphor-lumos`, its first separate output module. Lumos is a framework-free voxel-orb companion visualization for cognitive state; it complements the CRT-phosphor terminal aesthetic and does not replace it.
+Phosphor ships `:phosphor-core` alongside Lumos sibling modules. `:phosphor-lumos` is the framework-free voxel-orb companion visualization for cognitive state; `:phosphor-lumos-cli` is the JVM terminal surface module for projected Lumos frame data.
 
 ---
 
@@ -44,6 +44,7 @@ Signal → Field → Palette → Render → Choreography → Emitter → Surface
 |--------|---------|
 | `:phosphor-core` | Shared rendering pipeline — signals, fields, palettes, cells, choreography, emitters, and runtime bridges |
 | `:phosphor-lumos` | Voxel-orb companion visualization module for cognitive state, scaffolded for downstream Lumos frame APIs |
+| `:phosphor-lumos-cli` | JVM terminal DTO and future CLI renderer surface for projected Lumos voxel frames |
 
 ---
 
@@ -139,6 +140,8 @@ Phosphor compiles to:
 - **JavaScript** (Kotlin/JS IR)
 - **WebAssembly** (Kotlin/WASM)
 - **iOS** (x64, ARM64, Simulator ARM64 — packaged as XCFrameworks)
+
+The `:phosphor-lumos-cli` module is JVM-only by design; non-terminal Lumos surfaces live in separate sibling modules.
 
 ---
 

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/OklabColor.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/OklabColor.kt
@@ -1,6 +1,7 @@
 package link.socket.phosphor.color
 
 import kotlin.math.pow
+import kotlinx.serialization.Serializable
 
 /**
  * Linear RGB color with normalized channels.
@@ -56,6 +57,7 @@ data class LinearRgbColor(
  * [NeutralColor.lerpOklab] or [ColorRamp.sampleOklab] when clean perceptual
  * handoffs matter more than the extra conversion cost.
  */
+@Serializable
 data class OklabColor(
     val lightness: Float,
     val a: Float,

--- a/phosphor-lumos-cli/build.gradle.kts
+++ b/phosphor-lumos-cli/build.gradle.kts
@@ -1,0 +1,121 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+}
+
+val phosphorVersion: String by project
+
+group = "link.socket"
+version = phosphorVersion
+
+val hasInMemorySigningCredentials =
+    providers.gradleProperty("signingInMemoryKey").isPresent &&
+        providers.gradleProperty("signingInMemoryKeyId").isPresent &&
+        providers.gradleProperty("signingInMemoryKeyPassword").isPresent
+val hasFileSigningCredentials =
+    providers.gradleProperty("signing.secretKeyRingFile").isPresent &&
+        providers.gradleProperty("signing.keyId").isPresent &&
+        providers.gradleProperty("signing.password").isPresent
+val hasGpgSigningCredentials = providers.gradleProperty("signing.gnupg.keyName").isPresent
+val hasSigningCredentials =
+    hasInMemorySigningCredentials ||
+        hasFileSigningCredentials ||
+        hasGpgSigningCredentials
+val isPublishingToMavenLocal =
+    gradle.startParameter.taskNames.any {
+        it == "publishToMavenLocal" || it.endsWith(":publishToMavenLocal")
+    }
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":phosphor-lumos"))
+                api(project(":phosphor-core"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3")
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+            }
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+
+    configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
+
+    coordinates("link.socket", "phosphor-lumos-cli", version.toString())
+
+    pom {
+        name.set("Phosphor Lumos CLI")
+        description.set(
+            "JVM terminal DTOs and future CLI renderer surface for Phosphor's " +
+                "framework-free Lumos voxel-orb visualization.",
+        )
+        url.set("https://github.com/socket-link/phosphor")
+        inceptionYear.set("2026")
+
+        licenses {
+            license {
+                name.set("The Apache Software License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("socket-link")
+                name.set("Socket Link")
+                url.set("https://github.com/socket-link")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/socket-link/phosphor.git")
+            developerConnection.set("scm:git:ssh://git@github.com:socket-link/phosphor.git")
+            url.set("https://github.com/socket-link/phosphor")
+        }
+
+        issueManagement {
+            system.set("GitHub Issues")
+            url.set("https://github.com/socket-link/phosphor/issues")
+        }
+    }
+}
+
+plugins.withId("signing") {
+    extensions.configure<SigningExtension>("signing") {
+        if (hasGpgSigningCredentials) {
+            useGpgCmd()
+        }
+    }
+}
+
+tasks.withType<Sign>().configureEach {
+    enabled = hasSigningCredentials && !isPublishingToMavenLocal
+}

--- a/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/frame/LumosTerminalFrame.kt
+++ b/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/frame/LumosTerminalFrame.kt
@@ -1,0 +1,50 @@
+package link.socket.phosphor.lumos.cli.frame
+
+import kotlinx.serialization.Serializable
+import link.socket.phosphor.color.OklabColor
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelGlyphState
+
+/**
+ * Projected terminal-space representation of a Lumos voxel frame.
+ *
+ * The cells are row-major and must fill the entire character grid. This DTO is
+ * intentionally separate from Phosphor core's terminal frame shape because
+ * Lumos projection carries voxel-specific ambient and glyph state.
+ */
+@Serializable
+data class LumosTerminalFrame(
+    val width: Int,
+    val height: Int,
+    val cells: List<TerminalCell>,
+    val ambient: VoxelAmbient?,
+    val glyphState: VoxelGlyphState?,
+    val frameNumber: Long,
+) {
+    init {
+        require(width >= 0) { "width must be >= 0" }
+        require(height >= 0) { "height must be >= 0" }
+
+        val expectedCellCount = width.toLong() * height.toLong()
+        require(expectedCellCount <= Int.MAX_VALUE) {
+            "width * height must be <= Int.MAX_VALUE"
+        }
+        require(cells.size == expectedCellCount.toInt()) {
+            "cells size must equal width * height"
+        }
+    }
+
+    /**
+     * One terminal character cell in a projected Lumos frame.
+     *
+     * Null colors are transparent to the CLI renderer: no foreground or
+     * background escape sequence should be emitted for that channel.
+     */
+    @Serializable
+    data class TerminalCell(
+        val char: Char = ' ',
+        val foreground: OklabColor? = null,
+        val background: OklabColor? = null,
+        val bold: Boolean = false,
+    )
+}

--- a/phosphor-lumos-cli/src/commonTest/kotlin/link/socket/phosphor/lumos/cli/frame/LumosTerminalFrameTest.kt
+++ b/phosphor-lumos-cli/src/commonTest/kotlin/link/socket/phosphor/lumos/cli/frame/LumosTerminalFrameTest.kt
@@ -1,0 +1,108 @@
+package link.socket.phosphor.lumos.cli.frame
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.json.Json
+import link.socket.phosphor.color.OklabColor
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelGlyphState
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
+
+class LumosTerminalFrameTest {
+    @Test
+    fun `LumosTerminalFrame round-trips transparent blank frame via kotlinx-serialization`() {
+        val frame =
+            LumosTerminalFrame(
+                width = 10,
+                height = 10,
+                cells = List(100) { TerminalCell(' ', null, null) },
+                ambient = null,
+                glyphState = null,
+                frameNumber = 0L,
+            )
+
+        val json = Json { encodeDefaults = true }
+        val encoded = json.encodeToString(LumosTerminalFrame.serializer(), frame)
+        val decoded = json.decodeFromString(LumosTerminalFrame.serializer(), encoded)
+
+        assertEquals(frame, decoded)
+    }
+
+    @Test
+    fun `LumosTerminalFrame round-trips colors and voxel metadata`() {
+        val frame =
+            LumosTerminalFrame(
+                width = 2,
+                height = 2,
+                cells =
+                    List(4) { index ->
+                        if (index == 0) {
+                            TerminalCell(
+                                char = '*',
+                                foreground = OklabColor(lightness = 0.7f, a = 0.1f, b = -0.1f),
+                                background = OklabColor(lightness = 0.2f, a = -0.05f, b = 0.05f),
+                                bold = true,
+                            )
+                        } else {
+                            TerminalCell(' ', null, null)
+                        }
+                    },
+                ambient =
+                    VoxelAmbient(
+                        glowRed = 0.1f,
+                        glowGreen = 0.2f,
+                        glowBlue = 0.3f,
+                        glowIntensity = 0.4f,
+                        orbRotationX = 0.5f,
+                        orbRotationY = 0.6f,
+                        orbRotationZ = 0.7f,
+                    ),
+                glyphState =
+                    VoxelGlyphState(
+                        glyphName = "SPARK",
+                        progress = 0.8f,
+                        red = 0.9f,
+                        green = 0.85f,
+                        blue = 0.75f,
+                    ),
+                frameNumber = 0L,
+            )
+
+        val json = Json { encodeDefaults = true }
+        val encoded = json.encodeToString(LumosTerminalFrame.serializer(), frame)
+        val decoded = json.decodeFromString(LumosTerminalFrame.serializer(), encoded)
+
+        assertEquals(frame, decoded)
+    }
+
+    @Test
+    fun `cells must match declared grid size`() {
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                LumosTerminalFrame(
+                    width = 2,
+                    height = 2,
+                    cells = List(3) { TerminalCell() },
+                    ambient = null,
+                    glyphState = null,
+                    frameNumber = 0L,
+                )
+            }
+
+        assertEquals("cells size must equal width * height", failure.message)
+    }
+
+    @Test
+    fun `terminal cell defaults to transparent blank`() {
+        assertEquals(
+            TerminalCell(
+                char = ' ',
+                foreground = null,
+                background = null,
+                bold = false,
+            ),
+            TerminalCell(),
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "Phosphor"
 
 include(":phosphor-core")
 include(":phosphor-lumos")
+include(":phosphor-lumos-cli")
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
This Codex-authored PR completes PHO-21 by adding the JVM-only `:phosphor-lumos-cli` module and `LumosTerminalFrame` DTO with serializable terminal cells.

It also makes `OklabColor` serializable, wires the module into settings, docs, CI, and publish workflows, and adds JSON round-trip plus shape-contract tests.

Closes #41.

Validation: `./gradlew projects`, `./gradlew :phosphor-lumos-cli:assemble`, `./gradlew ktlintFormat`, `./gradlew jvmTest`, and `git diff --check`.