### PR TITLE
[codex] PHO-20/#40 add OKLab ANSI color map

### DIFF
--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/AnsiColorAdapter.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/AnsiColorAdapter.kt
@@ -5,14 +5,23 @@ package link.socket.phosphor.color
  */
 enum class AnsiColorMode {
     ANSI_256,
-    TRUE_COLOR,
+    TRUECOLOR,
+    ;
+
+    companion object {
+        @Deprecated(
+            message = "Use TRUECOLOR.",
+            replaceWith = ReplaceWith("AnsiColorMode.TRUECOLOR"),
+        )
+        val TRUE_COLOR: AnsiColorMode = TRUECOLOR
+    }
 }
 
 /**
  * Adapts neutral colors to ANSI terminal escape sequences.
  *
  * In ANSI_256 mode, colors are quantized to the nearest ANSI palette index.
- * In TRUE_COLOR mode, exact RGB values are emitted using 24-bit escapes.
+ * In TRUECOLOR mode, exact RGB values are emitted using 24-bit escapes.
  */
 class AnsiColorAdapter(
     private val mode: AnsiColorMode = AnsiColorMode.ANSI_256,
@@ -22,7 +31,7 @@ class AnsiColorAdapter(
     fun foreground(color: NeutralColor): String {
         return when (mode) {
             AnsiColorMode.ANSI_256 -> foregroundEscapeForCode(ansi256Code(color))
-            AnsiColorMode.TRUE_COLOR -> {
+            AnsiColorMode.TRUECOLOR -> {
                 "${ESC}38;2;${color.redInt};${color.greenInt};${color.blueInt}m"
             }
         }
@@ -31,7 +40,7 @@ class AnsiColorAdapter(
     fun background(color: NeutralColor): String {
         return when (mode) {
             AnsiColorMode.ANSI_256 -> backgroundEscapeForCode(ansi256Code(color))
-            AnsiColorMode.TRUE_COLOR -> {
+            AnsiColorMode.TRUECOLOR -> {
                 "${ESC}48;2;${color.redInt};${color.greenInt};${color.blueInt}m"
             }
         }
@@ -47,95 +56,10 @@ class AnsiColorAdapter(
 
         val DEFAULT: AnsiColorAdapter = AnsiColorAdapter()
 
-        fun ansi256ToNeutral(index: Int): NeutralColor = Ansi256Palette.colorAt(index)
+        fun ansi256ToNeutral(index: Int): NeutralColor = Ansi256Palette.neutralAt(index)
 
         fun foregroundEscapeForCode(code: Int): String = "${ESC}38;5;${code.coerceIn(0, 255)}m"
 
         fun backgroundEscapeForCode(code: Int): String = "${ESC}48;5;${code.coerceIn(0, 255)}m"
-    }
-}
-
-private object Ansi256Palette {
-    private val baseColors =
-        arrayOf(
-            intArrayOf(0, 0, 0),
-            intArrayOf(128, 0, 0),
-            intArrayOf(0, 128, 0),
-            intArrayOf(128, 128, 0),
-            intArrayOf(0, 0, 128),
-            intArrayOf(128, 0, 128),
-            intArrayOf(0, 128, 128),
-            intArrayOf(192, 192, 192),
-            intArrayOf(128, 128, 128),
-            intArrayOf(255, 0, 0),
-            intArrayOf(0, 255, 0),
-            intArrayOf(255, 255, 0),
-            intArrayOf(0, 0, 255),
-            intArrayOf(255, 0, 255),
-            intArrayOf(0, 255, 255),
-            intArrayOf(255, 255, 255),
-        )
-
-    private val colorCubeLevels = intArrayOf(0, 95, 135, 175, 215, 255)
-
-    private val colors: List<NeutralColor> = List(256) { index -> colorAtIndex(index) }
-
-    fun colorAt(index: Int): NeutralColor = colors[index.coerceIn(0, 255)]
-
-    fun nearestIndex(color: NeutralColor): Int {
-        val targetR = color.redInt
-        val targetG = color.greenInt
-        val targetB = color.blueInt
-
-        var bestIndex = 0
-        var bestDistance = Long.MAX_VALUE
-
-        for (index in colors.indices) {
-            val candidate = colors[index]
-            val dR = targetR - candidate.redInt
-            val dG = targetG - candidate.greenInt
-            val dB = targetB - candidate.blueInt
-            val distance = ((dR * dR) + (dG * dG) + (dB * dB)).toLong()
-
-            if (distance < bestDistance || (distance == bestDistance && index > bestIndex)) {
-                bestDistance = distance
-                bestIndex = index
-            }
-        }
-
-        return bestIndex
-    }
-
-    private fun colorAtIndex(index: Int): NeutralColor {
-        if (index < baseColors.size) {
-            val base = baseColors[index]
-            return NeutralColor.fromRgba(
-                red = base[0] / NeutralColor.CHANNEL_MAX_FLOAT,
-                green = base[1] / NeutralColor.CHANNEL_MAX_FLOAT,
-                blue = base[2] / NeutralColor.CHANNEL_MAX_FLOAT,
-                alpha = 1f,
-            )
-        }
-
-        if (index in 16..231) {
-            val cubeIndex = index - 16
-            val red = colorCubeLevels[cubeIndex / 36]
-            val green = colorCubeLevels[(cubeIndex % 36) / 6]
-            val blue = colorCubeLevels[cubeIndex % 6]
-            return NeutralColor.fromRgba(
-                red = red / NeutralColor.CHANNEL_MAX_FLOAT,
-                green = green / NeutralColor.CHANNEL_MAX_FLOAT,
-                blue = blue / NeutralColor.CHANNEL_MAX_FLOAT,
-                alpha = 1f,
-            )
-        }
-
-        val gray = 8 + ((index - 232) * 10)
-        return NeutralColor.fromRgba(
-            red = gray / NeutralColor.CHANNEL_MAX_FLOAT,
-            green = gray / NeutralColor.CHANNEL_MAX_FLOAT,
-            blue = gray / NeutralColor.CHANNEL_MAX_FLOAT,
-            alpha = 1f,
-        )
     }
 }

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/AnsiColorMap.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/AnsiColorMap.kt
@@ -1,0 +1,185 @@
+package link.socket.phosphor.color
+
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+/**
+ * Maps OKLab colors to terminal-ready ANSI escape sequences.
+ *
+ * This is the low-level bridge from Lumos' perceptual voxel colors to terminal
+ * foreground/background color wire formats. ANSI_256 mode searches the standard
+ * xterm 256-color palette; TRUECOLOR mode emits 24-bit sRGB channels.
+ */
+object AnsiColorMap {
+    private const val ESC = "\u001B["
+
+    /**
+     * Return a foreground color escape sequence for [color].
+     */
+    fun escape(
+        color: OklabColor,
+        mode: AnsiColorMode,
+    ): String {
+        val rgb = color.toPackedSrgb()
+        return when (mode) {
+            AnsiColorMode.ANSI_256 -> "${ESC}38;5;${Ansi256Palette.nearestIndex(rgb)}m"
+            AnsiColorMode.TRUECOLOR -> "${ESC}38;2;${red(rgb)};${green(rgb)};${blue(rgb)}m"
+        }
+    }
+
+    /**
+     * Return a background color escape sequence for [color].
+     */
+    fun backgroundEscape(
+        color: OklabColor,
+        mode: AnsiColorMode,
+    ): String {
+        val rgb = color.toPackedSrgb()
+        return when (mode) {
+            AnsiColorMode.ANSI_256 -> "${ESC}48;5;${Ansi256Palette.nearestIndex(rgb)}m"
+            AnsiColorMode.TRUECOLOR -> "${ESC}48;2;${red(rgb)};${green(rgb)};${blue(rgb)}m"
+        }
+    }
+
+    /**
+     * Return the nearest standard ANSI 256-color palette index for [color].
+     */
+    fun nearestPaletteIndex(color: OklabColor): Int = Ansi256Palette.nearestIndex(color.toPackedSrgb())
+}
+
+internal object Ansi256Palette {
+    private const val PALETTE_SIZE = 256
+    private const val COLOR_CUBE_START = 16
+    private const val COLOR_CUBE_END = 231
+    private const val GRAYSCALE_START = 232
+
+    private val baseColors =
+        intArrayOf(
+            pack(red = 0, green = 0, blue = 0),
+            pack(red = 128, green = 0, blue = 0),
+            pack(red = 0, green = 128, blue = 0),
+            pack(red = 128, green = 128, blue = 0),
+            pack(red = 0, green = 0, blue = 128),
+            pack(red = 128, green = 0, blue = 128),
+            pack(red = 0, green = 128, blue = 128),
+            pack(red = 192, green = 192, blue = 192),
+            pack(red = 128, green = 128, blue = 128),
+            pack(red = 255, green = 0, blue = 0),
+            pack(red = 0, green = 255, blue = 0),
+            pack(red = 255, green = 255, blue = 0),
+            pack(red = 0, green = 0, blue = 255),
+            pack(red = 255, green = 0, blue = 255),
+            pack(red = 0, green = 255, blue = 255),
+            pack(red = 255, green = 255, blue = 255),
+        )
+
+    private val colorCubeLevels = intArrayOf(0, 95, 135, 175, 215, 255)
+
+    private val colors = IntArray(PALETTE_SIZE) { index -> packedColorAt(index) }
+
+    val size: Int get() = colors.size
+
+    fun packedAt(index: Int): Int = colors[index.coerceIn(0, 255)]
+
+    fun neutralAt(index: Int): NeutralColor {
+        val rgb = packedAt(index)
+        return NeutralColor.fromRgba(
+            red = red(rgb) / NeutralColor.CHANNEL_MAX_FLOAT,
+            green = green(rgb) / NeutralColor.CHANNEL_MAX_FLOAT,
+            blue = blue(rgb) / NeutralColor.CHANNEL_MAX_FLOAT,
+            alpha = 1f,
+        )
+    }
+
+    fun nearestIndex(color: NeutralColor): Int =
+        nearestIndex(
+            pack(
+                red = color.redInt,
+                green = color.greenInt,
+                blue = color.blueInt,
+            ),
+        )
+
+    fun nearestIndex(rgb: Int): Int {
+        val targetR = red(rgb)
+        val targetG = green(rgb)
+        val targetB = blue(rgb)
+
+        var bestIndex = 0
+        var bestDistance = Long.MAX_VALUE
+
+        for (index in colors.indices) {
+            val candidate = colors[index]
+            val dR = targetR - red(candidate)
+            val dG = targetG - green(candidate)
+            val dB = targetB - blue(candidate)
+            val distance = ((dR * dR) + (dG * dG) + (dB * dB)).toLong()
+
+            if (distance < bestDistance || (distance == bestDistance && index > bestIndex)) {
+                bestDistance = distance
+                bestIndex = index
+            }
+        }
+
+        return bestIndex
+    }
+
+    private fun packedColorAt(index: Int): Int {
+        if (index < baseColors.size) return baseColors[index]
+
+        if (index in COLOR_CUBE_START..COLOR_CUBE_END) {
+            val cubeIndex = index - COLOR_CUBE_START
+            return pack(
+                red = colorCubeLevels[cubeIndex / 36],
+                green = colorCubeLevels[(cubeIndex % 36) / 6],
+                blue = colorCubeLevels[cubeIndex % 6],
+            )
+        }
+
+        val gray = 8 + ((index - GRAYSCALE_START) * 10)
+        return pack(red = gray, green = gray, blue = gray)
+    }
+}
+
+private fun OklabColor.toPackedSrgb(): Int {
+    val lightness = lightness.toDouble()
+    val a = a.toDouble()
+    val b = b.toDouble()
+
+    val lPrime = lightness + (0.3963377774 * a) + (0.2158037573 * b)
+    val mPrime = lightness - (0.1055613458 * a) - (0.0638541728 * b)
+    val sPrime = lightness - (0.0894841775 * a) - (1.2914855480 * b)
+
+    val l = lPrime * lPrime * lPrime
+    val m = mPrime * mPrime * mPrime
+    val s = sPrime * sPrime * sPrime
+
+    return pack(
+        red = ((4.0767416621 * l) - (3.3077115913 * m) + (0.2309699292 * s)).toSrgbByte(),
+        green = ((-1.2684380046 * l) + (2.6097574011 * m) - (0.3413193965 * s)).toSrgbByte(),
+        blue = ((-0.0041960863 * l) - (0.7034186147 * m) + (1.7076147010 * s)).toSrgbByte(),
+    )
+}
+
+private fun Double.toSrgbByte(): Int {
+    val encoded =
+        if (this <= 0.0031308) {
+            12.92 * this
+        } else {
+            (1.055 * pow(1.0 / 2.4)) - 0.055
+        }
+
+    return (encoded.coerceIn(0.0, 1.0) * NeutralColor.CHANNEL_MAX_INT).roundToInt()
+}
+
+private fun pack(
+    red: Int,
+    green: Int,
+    blue: Int,
+): Int = (red.coerceIn(0, 255) shl 16) or (green.coerceIn(0, 255) shl 8) or blue.coerceIn(0, 255)
+
+private fun red(rgb: Int): Int = (rgb shr 16) and 0xFF
+
+private fun green(rgb: Int): Int = (rgb shr 8) and 0xFF
+
+private fun blue(rgb: Int): Int = rgb and 0xFF

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/color/AnsiColorAdapterTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/color/AnsiColorAdapterTest.kt
@@ -82,7 +82,7 @@ class AnsiColorAdapterTest {
 
     @Test
     fun `true color mode emits 24 bit escapes`() {
-        val adapter = AnsiColorAdapter(mode = AnsiColorMode.TRUE_COLOR)
+        val adapter = AnsiColorAdapter(mode = AnsiColorMode.TRUECOLOR)
         val color = NeutralColor.fromHex("#3366CC")
 
         assertEquals("\u001B[38;2;51;102;204m", adapter.foreground(color))

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/color/AnsiColorMapTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/color/AnsiColorMapTest.kt
@@ -1,0 +1,73 @@
+package link.socket.phosphor.color
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AnsiColorMapTest {
+    @Test
+    fun `linear rgb gamma round trip preserves midpoint srgb channel`() {
+        val midpoint = NeutralColor.fromHex("#808080")
+        val roundTripped = LinearRgbColor.fromSrgb(midpoint).toSrgb()
+
+        assertEquals(midpoint, roundTripped)
+    }
+
+    @Test
+    fun `ansi 256 palette table contains standard cube boundaries`() {
+        assertEquals(256, Ansi256Palette.size)
+        assertEquals(NeutralColor.BLACK, AnsiColorAdapter.ansi256ToNeutral(16))
+        assertEquals(NeutralColor.WHITE, AnsiColorAdapter.ansi256ToNeutral(231))
+    }
+
+    @Test
+    fun `pure primary colors snap to color cube indices`() {
+        assertEquals(196, NeutralColor.fromHex("#FF0000").nearestPaletteIndex())
+        assertEquals(46, NeutralColor.fromHex("#00FF00").nearestPaletteIndex())
+        assertEquals(21, NeutralColor.fromHex("#0000FF").nearestPaletteIndex())
+    }
+
+    @Test
+    fun `pure black and white prefer color cube duplicates over base colors`() {
+        assertEquals(16, NeutralColor.BLACK.nearestPaletteIndex())
+        assertEquals(231, NeutralColor.WHITE.nearestPaletteIndex())
+    }
+
+    @Test
+    fun `near grayscale snaps to grayscale ramp instead of color cube`() {
+        val index = NeutralColor.fromHex("#808080").nearestPaletteIndex()
+
+        assertEquals(244, index)
+        assertTrue(index in 232..255)
+    }
+
+    @Test
+    fun `truecolor mode emits raw foreground and background twenty four bit escapes`() {
+        val red = NeutralColor.fromHex("#FF0000").toOklab()
+        val cobalt = NeutralColor.fromHex("#3366CC").toOklab()
+
+        assertEquals("\u001B[38;2;255;0;0m", AnsiColorMap.escape(red, AnsiColorMode.TRUECOLOR))
+        assertEquals("\u001B[48;2;255;0;0m", AnsiColorMap.backgroundEscape(red, AnsiColorMode.TRUECOLOR))
+        assertEquals("\u001B[38;2;51;102;204m", AnsiColorMap.escape(cobalt, AnsiColorMode.TRUECOLOR))
+    }
+
+    @Test
+    fun `ansi 256 mode emits foreground and background palette escapes`() {
+        val red = NeutralColor.fromHex("#FF0000").toOklab()
+
+        assertEquals("\u001B[38;5;196m", AnsiColorMap.escape(red, AnsiColorMode.ANSI_256))
+        assertEquals("\u001B[48;5;196m", AnsiColorMap.backgroundEscape(red, AnsiColorMode.ANSI_256))
+    }
+
+    @Test
+    fun `near saturated lumos atmosphere colors quantize to stable palette regions`() {
+        assertEquals(63, NeutralColor.fromHsl(244f, 0.85f, 0.60f).nearestPaletteIndex())
+        assertEquals(75, NeutralColor.fromHsl(197f, 0.85f, 0.60f).nearestPaletteIndex())
+        assertEquals(215, NeutralColor.fromHsl(32f, 0.85f, 0.60f).nearestPaletteIndex())
+        assertEquals(135, NeutralColor.fromHsl(280f, 0.85f, 0.60f).nearestPaletteIndex())
+    }
+
+    private fun NeutralColor.toOklab(): OklabColor = OklabColor.fromSrgb(this)
+
+    private fun NeutralColor.nearestPaletteIndex(): Int = AnsiColorMap.nearestPaletteIndex(toOklab())
+}


### PR DESCRIPTION
Implements PHO-20 / GitHub #40 by adding `AnsiColorMap` for OKLab foreground/background escapes in ANSI 256 and truecolor modes.

The palette table is shared with the existing neutral-color ANSI adapter, and `TRUECOLOR` is now the public enum spelling with deprecated `TRUE_COLOR` compatibility.

Tests cover gamma round-trip, palette boundaries, primary colors, grayscale quantization, truecolor output, and Lumos atmosphere hues.

Validation: `./gradlew ktlintFormat`; `./gradlew jvmTest`.

Closes #40