### PR TITLE
Speed up CI: drop redundant macOS test job, fold web/iOS tests into existing jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   jvm:
-    name: JVM And Lint
+    name: JVM, Lint, Web
     runs-on: ubuntu-latest
 
     steps:
@@ -31,17 +31,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run JVM tests
-        run: ./gradlew jvmTest
+      - name: Run JVM and web tests
+        run: ./gradlew jvmTest jsTest wasmJsTest
 
       - name: Verify formatting
-        run: ./gradlew ktlintFormat --no-rebuild
+        run: ./gradlew ktlintCheck
 
-      - name: Check formatting diff
-        run: git diff --exit-code
-
-  ios_compile:
-    name: iOS Compile
+  ios:
+    name: iOS Compile And Test
     runs-on: macos-latest
 
     steps:
@@ -57,37 +54,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Compile iOS targets
-        run: ./gradlew :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64
-
-  test:
-    name: Tests
-    runs-on: macos-latest
-    needs: [jvm, ios_compile]
-    if: ${{ always() }}
-
-    steps:
-      - name: Enforce required checks
-        run: |
-          if [ "${{ needs.jvm.result }}" != "success" ] || [ "${{ needs.ios_compile.result }}" != "success" ]; then
-            echo "Required CI jobs did not all pass."
-            exit 1
-          fi
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'zulu'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Run build
-        run: ./gradlew build
-
-      - name: Run all tests
-        run: ./gradlew allTests
+      - name: Compile iOS device target and run simulator tests
+        run: ./gradlew :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64 iosSimulatorArm64Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 #Gradle
 org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.parallel=true
+org.gradle.caching=true
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
## Summary
I removed the gating `test` job from `.github/workflows/ci.yml` — it spun up a second macOS runner serialized behind the other two jobs and re-ran `jvmTest` (via `./gradlew build`) and `allTests`, duplicating work the `jvm` and `ios_compile` jobs had already done. Native simulator tests now run in the iOS job (`iosSimulatorArm64Test`), JS/Wasm tests run in the Linux job, and `ktlintFormat --no-rebuild` + `git diff --exit-code` is replaced with `ktlintCheck`. `gradle.properties` gains `org.gradle.parallel=true` and `org.gradle.caching=true` so the remote build cache from `setup-gradle@v4` actually pays off across runs.

## Test plan
- [ ] CI green on this PR with the new two-job layout
- [ ] Confirm iOS simulator tests execute (look for `iosSimulatorArm64Test` task output)
- [ ] Confirm `jsTest` and `wasmJsTest` run in the Linux job

🤖 Generated with [Claude Code](https://claude.com/claude-code)