### PR TITLE
PHO-23/#43 add CliGlyph ASCII glyph overlay

### DIFF
--- a/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/glyph/CliGlyph.kt
+++ b/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/glyph/CliGlyph.kt
@@ -1,0 +1,340 @@
+package link.socket.phosphor.lumos.cli.glyph
+
+import link.socket.phosphor.color.NeutralColor
+import link.socket.phosphor.color.OklabColor
+import link.socket.phosphor.lumos.LumosGlyph
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
+
+/**
+ * Row-major rectangular bitmask describing a 2D glyph footprint.
+ *
+ * `mask[y * width + x]` is `true` for cells that belong to the glyph (and so
+ * replace the underlying orb cell when the glyph is fully visible) and `false`
+ * for cells that let the orb show through.
+ */
+data class CharGrid(
+    val width: Int,
+    val height: Int,
+    val mask: List<Boolean>,
+    val chars: List<Char> = List(width * height) { GLYPH_FILL_CHAR },
+) {
+    init {
+        require(width >= 0) { "width must be >= 0" }
+        require(height >= 0) { "height must be >= 0" }
+        require(mask.size == width * height) { "mask size must equal width * height" }
+        require(chars.size == width * height) { "chars size must equal width * height" }
+    }
+
+    companion object {
+        internal const val GLYPH_FILL_CHAR: Char = '#'
+    }
+}
+
+/**
+ * 2D ASCII analog of the 3D voxel glyph carving from PHO-18.
+ *
+ * Replaces frame cells that fall under the active glyph's footprint with the
+ * glyph's character and accent color. Cells outside the footprint, and cells
+ * skipped by intensity stippling, are left untouched so the orb shows through.
+ *
+ * The overlay is a pure function: it returns a new [LumosTerminalFrame] and
+ * never mutates its input.
+ */
+object CliGlyph {
+    /**
+     * CHECK — short `\` stroke meeting a longer `/` stroke at row 3 col 1.
+     *
+     * ```
+     * . . . . /
+     * . . . / .
+     * \ . / . .
+     * . \ . . .
+     * . . . . .
+     * ```
+     */
+    val CHECK: CharGrid =
+        buildGrid(
+            width = 5,
+            height = 5,
+            rows =
+                listOf(
+                    "    /",
+                    "   / ",
+                    "\\ /  ",
+                    " \\   ",
+                    "     ",
+                ),
+        )
+
+    /**
+     * EXCLAIM — vertical `|` bar with a `.` dot below.
+     *
+     * ```
+     * . | .
+     * . | .
+     * . | .
+     * . . .
+     * . . .
+     * ```
+     */
+    val EXCLAIM: CharGrid =
+        buildGrid(
+            width = 3,
+            height = 5,
+            rows =
+                listOf(
+                    " | ",
+                    " | ",
+                    " | ",
+                    "   ",
+                    " . ",
+                ),
+        )
+
+    /**
+     * QUESTION — top curve `_/`, right-side hook `\` then `|`, and a `.` dot
+     * below.
+     *
+     * ```
+     * _ / . . .
+     * . . \ . .
+     * . . | . .
+     * . . . . .
+     * . . . . .
+     * ```
+     */
+    val QUESTION: CharGrid =
+        buildGrid(
+            width = 5,
+            height = 5,
+            rows =
+                listOf(
+                    "_/   ",
+                    "  \\  ",
+                    "  |  ",
+                    "     ",
+                    "  .  ",
+                ),
+        )
+
+    /**
+     * HEART — filled `*` heart with two lobes on top and a point at the
+     * bottom.
+     *
+     * ```
+     * . * . * .
+     * * * * * *
+     * * * * * *
+     * . * * * .
+     * . . * . .
+     * ```
+     */
+    val HEART: CharGrid =
+        buildGrid(
+            width = 5,
+            height = 5,
+            rows =
+                listOf(
+                    " * * ",
+                    "*****",
+                    "*****",
+                    " *** ",
+                    "  *  ",
+                ),
+        )
+
+    /**
+     * STAR — five-point asterisk with diagonal `\` and `/` spokes and a `+`
+     * at the center.
+     *
+     * ```
+     * . . * . .
+     * . \ | / .
+     * * - + - *
+     * . / | \ .
+     * . . * . .
+     * ```
+     */
+    val STAR: CharGrid =
+        buildGrid(
+            width = 5,
+            height = 5,
+            rows =
+                listOf(
+                    "  *  ",
+                    " \\|/ ",
+                    "*-+-*",
+                    " /|\\ ",
+                    "  *  ",
+                ),
+        )
+
+    /**
+     * LIGHTNING — zigzag bolt: `\` strokes descending right, then `/` strokes
+     * descending left.
+     *
+     * ```
+     * . \ . . .
+     * . . \ . .
+     * . . / . .
+     * . / . . .
+     * / . . . .
+     * ```
+     */
+    val LIGHTNING: CharGrid =
+        buildGrid(
+            width = 5,
+            height = 5,
+            rows =
+                listOf(
+                    " \\   ",
+                    "  \\  ",
+                    "  /  ",
+                    " /   ",
+                    "/    ",
+                ),
+        )
+
+    /**
+     * Project [frame]'s active glyph (if any) onto the cell grid and return a
+     * new frame with the glyph drawn over the orb.
+     *
+     * Returns [frame] unchanged when there is no glyph, when the glyph name is
+     * unknown, when the glyph footprint would not fit on the grid, or when the
+     * glyph's fade envelope is fully transparent (intensity 0).
+     *
+     * At intermediate intensities, cells flip to the glyph based on a
+     * deterministic hash of `(x, y, frameNumber)` so animation is stable
+     * frame-to-frame and reproducible in tests.
+     */
+    fun overlay(frame: LumosTerminalFrame): LumosTerminalFrame {
+        val glyphState = frame.glyphState ?: return frame
+        val glyph = LumosGlyph.entries.firstOrNull { it.name == glyphState.glyphName } ?: return frame
+        val intensity = visibilityFromProgress(glyphState.progress)
+        if (intensity <= 0f) return frame
+        if (frame.width == 0 || frame.height == 0) return frame
+
+        val grid = gridFor(glyph)
+        if (grid.width > frame.width || grid.height > frame.height) return frame
+
+        val accent =
+            OklabColor.fromSrgb(
+                NeutralColor.fromRgba(
+                    red = glyphState.red,
+                    green = glyphState.green,
+                    blue = glyphState.blue,
+                ),
+            )
+
+        val offsetX = (frame.width - grid.width) / 2
+        val offsetY = (frame.height - grid.height) / 2
+
+        val newCells = frame.cells.toMutableList()
+        for (gy in 0 until grid.height) {
+            for (gx in 0 until grid.width) {
+                val gridIndex = gy * grid.width + gx
+                if (!grid.mask[gridIndex]) continue
+
+                val fx = offsetX + gx
+                val fy = offsetY + gy
+                val threshold = stippleThreshold(fx, fy, frame.frameNumber)
+                if (intensity < threshold) continue
+
+                val cellIndex = fy * frame.width + fx
+                val previous = newCells[cellIndex]
+                newCells[cellIndex] =
+                    TerminalCell(
+                        char = grid.chars[gridIndex],
+                        foreground = accent,
+                        background = previous.background,
+                        bold = previous.bold,
+                    )
+            }
+        }
+        return frame.copy(cells = newCells)
+    }
+
+    /** Returns the [CharGrid] footprint for [glyph]. */
+    fun gridFor(glyph: LumosGlyph): CharGrid =
+        when (glyph) {
+            LumosGlyph.CHECK -> CHECK
+            LumosGlyph.EXCLAIM -> EXCLAIM
+            LumosGlyph.QUESTION -> QUESTION
+            LumosGlyph.HEART -> HEART
+            LumosGlyph.STAR -> STAR
+            LumosGlyph.LIGHTNING -> LIGHTNING
+        }
+
+    /**
+     * Mirrors the fade-in/hold/fade-out envelope from `GlyphLifecycle.visibility`
+     * so the overlay's stipple intensity matches the 3D pipeline's voxel-color
+     * lerp factor at the same progress value.
+     */
+    internal fun visibilityFromProgress(progress: Float): Float {
+        val p = progress.coerceIn(0f, 1f)
+        return when {
+            p < FADE_IN -> smoothstep(0f, FADE_IN, p)
+            p > FADE_OUT -> 1f - smoothstep(FADE_OUT, 1f, p)
+            else -> 1f
+        }
+    }
+
+    /**
+     * Deterministic hash of `(x, y, frameNumber)` mapped to `[0, 1]`. Used as
+     * the per-cell stipple threshold: at intensity `i`, a cell flips to the
+     * glyph when `threshold <= i`. Stable for identical inputs across calls
+     * and processes (no RNG state).
+     */
+    internal fun stippleThreshold(
+        x: Int,
+        y: Int,
+        frameNumber: Long,
+    ): Float {
+        var h = x * PRIME_X
+        h = h xor (y * PRIME_Y)
+        h = h xor (frameNumber.toInt() * PRIME_T)
+        h = h xor (h ushr 16)
+        h *= MURMUR_K1
+        h = h xor (h ushr 13)
+        h *= MURMUR_K2
+        h = h xor (h ushr 16)
+        val nonNegative = h and Int.MAX_VALUE
+        return nonNegative.toFloat() / Int.MAX_VALUE.toFloat()
+    }
+
+    private fun smoothstep(
+        edge0: Float,
+        edge1: Float,
+        x: Float,
+    ): Float {
+        val t = ((x - edge0) / (edge1 - edge0)).coerceIn(0f, 1f)
+        return t * t * (3f - 2f * t)
+    }
+
+    private fun buildGrid(
+        width: Int,
+        height: Int,
+        rows: List<String>,
+    ): CharGrid {
+        require(rows.size == height) { "rows.size must equal height" }
+        val mask = ArrayList<Boolean>(width * height)
+        val chars = ArrayList<Char>(width * height)
+        for (row in rows) {
+            require(row.length == width) { "each row must be exactly width characters" }
+            for (ch in row) {
+                mask += ch != ' '
+                chars += ch
+            }
+        }
+        return CharGrid(width, height, mask, chars)
+    }
+
+    private const val FADE_IN: Float = 0.20f
+    private const val FADE_OUT: Float = 0.80f
+    private const val PRIME_X: Int = 73856093
+    private const val PRIME_Y: Int = 19349663
+    private const val PRIME_T: Int = 83492791
+    private const val MURMUR_K1: Int = -1640531535
+    private const val MURMUR_K2: Int = -1028477387
+}

--- a/phosphor-lumos-cli/src/commonTest/kotlin/link/socket/phosphor/lumos/cli/glyph/CliGlyphTest.kt
+++ b/phosphor-lumos-cli/src/commonTest/kotlin/link/socket/phosphor/lumos/cli/glyph/CliGlyphTest.kt
@@ -1,0 +1,433 @@
+package link.socket.phosphor.lumos.cli.glyph
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import link.socket.phosphor.color.NeutralColor
+import link.socket.phosphor.color.OklabColor
+import link.socket.phosphor.lumos.LumosGlyph
+import link.socket.phosphor.lumos.VoxelGlyphState
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
+
+class CliGlyphTest {
+    @Test
+    fun `CharGrid centre-only mask validates correctly`() {
+        val grid = CharGrid(3, 3, List(9) { it == 4 })
+        assertEquals(9, grid.mask.size)
+        assertTrue(grid.mask[4])
+        assertEquals(8, grid.mask.count { !it })
+    }
+
+    @Test
+    fun `CharGrid rejects mask size mismatch`() {
+        assertFailsWith<IllegalArgumentException> {
+            CharGrid(width = 3, height = 3, mask = List(8) { false })
+        }
+    }
+
+    @Test
+    fun `every canonical glyph constant has consistent dimensions`() {
+        for (glyph in LumosGlyph.entries) {
+            val grid = CliGlyph.gridFor(glyph)
+            assertEquals(
+                grid.width * grid.height,
+                grid.mask.size,
+                "${glyph.name} mask size",
+            )
+            assertEquals(
+                grid.width * grid.height,
+                grid.chars.size,
+                "${glyph.name} chars size",
+            )
+            assertTrue(grid.mask.any { it }, "${glyph.name} must mark at least one cell")
+        }
+    }
+
+    @Test
+    fun `overlay returns same frame when glyph state is null`() {
+        val frame = blankFrame(width = 10, height = 6, glyphState = null)
+        val result = CliGlyph.overlay(frame)
+        assertSame(frame, result)
+    }
+
+    @Test
+    fun `overlay returns same frame when glyph name is unknown`() {
+        val frame =
+            blankFrame(
+                width = 10,
+                height = 6,
+                glyphState = glyphState(name = "MYSTERY", progress = 0.5f),
+            )
+        val result = CliGlyph.overlay(frame)
+        assertSame(frame, result)
+    }
+
+    @Test
+    fun `intensity zero leaves the orb untouched`() {
+        val frame =
+            blankFrame(
+                width = 10,
+                height = 6,
+                glyphState = glyphState(name = LumosGlyph.CHECK.name, progress = 0f),
+            )
+        val result = CliGlyph.overlay(frame)
+        assertEquals(frame.cells, result.cells)
+    }
+
+    @Test
+    fun `glyph fully present at hold-phase intensity`() {
+        val frame =
+            blankFrame(
+                width = 11,
+                height = 9,
+                glyphState = glyphState(name = LumosGlyph.CHECK.name, progress = 0.5f),
+            )
+
+        val result = CliGlyph.overlay(frame)
+
+        val grid = CliGlyph.CHECK
+        val offsetX = (frame.width - grid.width) / 2
+        val offsetY = (frame.height - grid.height) / 2
+        val expectedAccent = expectedAccent(LumosGlyph.CHECK)
+
+        for (gy in 0 until grid.height) {
+            for (gx in 0 until grid.width) {
+                val gridIndex = gy * grid.width + gx
+                val cellIndex = (offsetY + gy) * frame.width + (offsetX + gx)
+                val cell = result.cells[cellIndex]
+                if (grid.mask[gridIndex]) {
+                    assertEquals(grid.chars[gridIndex], cell.char)
+                    val foreground = cell.foreground
+                    assertNotNull(foreground)
+                    assertOklabClose(expectedAccent, foreground)
+                } else {
+                    assertEquals(frame.cells[cellIndex], cell)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `cells outside the glyph footprint are unchanged at full intensity`() {
+        val frame =
+            blankFrame(
+                width = 12,
+                height = 8,
+                glyphState = glyphState(name = LumosGlyph.HEART.name, progress = 0.5f),
+            )
+
+        val result = CliGlyph.overlay(frame)
+        val grid = CliGlyph.HEART
+        val offsetX = (frame.width - grid.width) / 2
+        val offsetY = (frame.height - grid.height) / 2
+
+        for (y in 0 until frame.height) {
+            for (x in 0 until frame.width) {
+                val insideX = x in offsetX until (offsetX + grid.width)
+                val insideY = y in offsetY until (offsetY + grid.height)
+                if (insideX && insideY) continue
+                val index = y * frame.width + x
+                assertEquals(frame.cells[index], result.cells[index])
+            }
+        }
+    }
+
+    @Test
+    fun `overlay is deterministic for the same input`() {
+        val frame =
+            blankFrame(
+                width = 12,
+                height = 8,
+                glyphState = glyphState(name = LumosGlyph.STAR.name, progress = 0.10f),
+                frameNumber = 42L,
+            )
+        val a = CliGlyph.overlay(frame)
+        val b = CliGlyph.overlay(frame)
+        assertEquals(a.cells, b.cells)
+    }
+
+    @Test
+    fun `partial intensity stipples a fraction of cells in the footprint`() {
+        val width = 12
+        val height = 8
+        val frame =
+            blankFrame(
+                width = width,
+                height = height,
+                glyphState = glyphState(name = LumosGlyph.HEART.name, progress = 0.10f),
+                frameNumber = 7L,
+            )
+        val result = CliGlyph.overlay(frame)
+
+        val grid = CliGlyph.HEART
+        val offsetX = (width - grid.width) / 2
+        val offsetY = (height - grid.height) / 2
+        var filled = 0
+        var unchanged = 0
+        var footprint = 0
+        for (gy in 0 until grid.height) {
+            for (gx in 0 until grid.width) {
+                if (!grid.mask[gy * grid.width + gx]) continue
+                footprint++
+                val cellIndex = (offsetY + gy) * width + (offsetX + gx)
+                if (result.cells[cellIndex] == frame.cells[cellIndex]) {
+                    unchanged++
+                } else {
+                    filled++
+                }
+            }
+        }
+        assertTrue(filled in 1 until footprint, "expected partial fill, got $filled of $footprint")
+        assertTrue(unchanged in 1 until footprint, "expected some untouched cells, got $unchanged")
+    }
+
+    @Test
+    fun `overlay does not mutate the input frame`() {
+        val frame =
+            blankFrame(
+                width = 11,
+                height = 9,
+                glyphState = glyphState(name = LumosGlyph.EXCLAIM.name, progress = 0.5f),
+            )
+        val before = frame.cells.toList()
+        val result = CliGlyph.overlay(frame)
+        assertEquals(before, frame.cells)
+        assertNotSame(frame.cells, result.cells)
+    }
+
+    @Test
+    fun `overlay returns same frame when grid does not fit`() {
+        val frame =
+            blankFrame(
+                width = 2,
+                height = 2,
+                glyphState = glyphState(name = LumosGlyph.HEART.name, progress = 0.5f),
+            )
+        val result = CliGlyph.overlay(frame)
+        assertSame(frame, result)
+    }
+
+    @Test
+    fun `visibility matches GlyphLifecycle envelope at key progress values`() {
+        assertEquals(0f, CliGlyph.visibilityFromProgress(0f))
+        assertEquals(1f, CliGlyph.visibilityFromProgress(0.20f))
+        assertEquals(1f, CliGlyph.visibilityFromProgress(0.50f))
+        assertEquals(1f, CliGlyph.visibilityFromProgress(0.80f))
+        assertEquals(0f, CliGlyph.visibilityFromProgress(1f))
+    }
+
+    @Test
+    fun `stipple threshold is stable and well-bounded`() {
+        for (seed in 0 until 100) {
+            val t = CliGlyph.stippleThreshold(seed % 17, seed % 11, seed.toLong())
+            assertTrue(t in 0f..1f, "threshold out of range for seed=$seed: $t")
+        }
+        assertEquals(
+            CliGlyph.stippleThreshold(3, 4, 5L),
+            CliGlyph.stippleThreshold(3, 4, 5L),
+        )
+    }
+
+    @Test
+    fun `snapshot — CHECK at hold intensity`() {
+        assertSnapshot(
+            glyph = LumosGlyph.CHECK,
+            expected =
+                """
+                |.........
+                |.........
+                |....../..
+                |...../...
+                |..\./....
+                |...\.....
+                |.........
+                |.........
+                |.........
+                """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun `snapshot — EXCLAIM at hold intensity`() {
+        assertSnapshot(
+            glyph = LumosGlyph.EXCLAIM,
+            expected =
+                """
+                |.........
+                |.........
+                |....|....
+                |....|....
+                |....|....
+                |.........
+                |.........
+                |.........
+                |.........
+                """.trimMargin(),
+            // EXCLAIM is 3x5; column-7 cell (`.`) at row 6 col 4 is the dot.
+            extraAssert = { result ->
+                assertEquals('.', result.cells[6 * 9 + 4].char)
+            },
+        )
+    }
+
+    @Test
+    fun `snapshot — QUESTION at hold intensity`() {
+        assertSnapshot(
+            glyph = LumosGlyph.QUESTION,
+            expected =
+                """
+                |.........
+                |.........
+                |.._/.....
+                |....\....
+                |....|....
+                |.........
+                |.........
+                |.........
+                |.........
+                """.trimMargin(),
+            extraAssert = { result ->
+                assertEquals('.', result.cells[6 * 9 + 4].char)
+            },
+        )
+    }
+
+    @Test
+    fun `snapshot — HEART at hold intensity`() {
+        assertSnapshot(
+            glyph = LumosGlyph.HEART,
+            expected =
+                """
+                |.........
+                |.........
+                |...*.*...
+                |..*****..
+                |..*****..
+                |...***...
+                |....*....
+                |.........
+                |.........
+                """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun `snapshot — STAR at hold intensity`() {
+        assertSnapshot(
+            glyph = LumosGlyph.STAR,
+            expected =
+                """
+                |.........
+                |.........
+                |....*....
+                |...\|/...
+                |..*-+-*..
+                |.../|\...
+                |....*....
+                |.........
+                |.........
+                """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun `snapshot — LIGHTNING at hold intensity`() {
+        assertSnapshot(
+            glyph = LumosGlyph.LIGHTNING,
+            expected =
+                """
+                |.........
+                |.........
+                |...\.....
+                |....\....
+                |..../....
+                |.../.....
+                |../......
+                |.........
+                |.........
+                """.trimMargin(),
+        )
+    }
+
+    private fun assertSnapshot(
+        glyph: LumosGlyph,
+        expected: String,
+        extraAssert: ((LumosTerminalFrame) -> Unit)? = null,
+    ) {
+        val width = 9
+        val height = 9
+        val frame =
+            blankFrame(
+                width = width,
+                height = height,
+                glyphState = glyphState(name = glyph.name, progress = 0.5f),
+            )
+        val result = CliGlyph.overlay(frame)
+        val actual =
+            buildString {
+                for (y in 0 until height) {
+                    for (x in 0 until width) {
+                        val ch = result.cells[y * width + x].char
+                        append(if (ch == ' ') '.' else ch)
+                    }
+                    if (y != height - 1) append('\n')
+                }
+            }
+        val normalizedExpected = expected.lines().joinToString("\n") { it }
+        assertEquals(normalizedExpected, actual, "snapshot for $glyph")
+        extraAssert?.invoke(result)
+    }
+
+    private fun blankFrame(
+        width: Int,
+        height: Int,
+        glyphState: VoxelGlyphState?,
+        frameNumber: Long = 0L,
+    ): LumosTerminalFrame =
+        LumosTerminalFrame(
+            width = width,
+            height = height,
+            cells = List(width * height) { TerminalCell(char = '.') },
+            ambient = null,
+            glyphState = glyphState,
+            frameNumber = frameNumber,
+        )
+
+    private fun glyphState(
+        name: String,
+        progress: Float,
+    ): VoxelGlyphState =
+        VoxelGlyphState(
+            glyphName = name,
+            progress = progress,
+            red = 0.40f,
+            green = 0.75f,
+            blue = 0.55f,
+        )
+
+    private fun expectedAccent(glyph: LumosGlyph): OklabColor {
+        val state = glyphState(glyph.name, 0.5f)
+        return OklabColor.fromSrgb(
+            NeutralColor.fromRgba(state.red, state.green, state.blue),
+        )
+    }
+
+    private fun assertOklabClose(
+        expected: OklabColor,
+        actual: OklabColor,
+        tolerance: Float = 1e-4f,
+    ) {
+        assertTrue(
+            abs(expected.lightness - actual.lightness) < tolerance &&
+                abs(expected.a - actual.a) < tolerance &&
+                abs(expected.b - actual.b) < tolerance,
+            "expected $expected to be ≈ $actual",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CliGlyph` in `phosphor-lumos-cli` that overlays the six canonical `LumosGlyph` shapes (CHECK, EXCLAIM, QUESTION, HEART, STAR, LIGHTNING) onto a `LumosTerminalFrame` as the 2D analog of PHO-18's voxel carving.
- Introduces a `CharGrid(width, height, mask, chars)` data class with hand-authored ASCII art constants per glyph; the overlay centers the footprint, replaces matched cells with the glyph character + OKLab accent, and applies deterministic Murmur-style hash stippling at intermediate intensities.
- Intensity is re-derived from `VoxelGlyphState.progress` using the same fade-in/hold/fade-out smoothstep as `GlyphLifecycle.visibility`, since the DTO only carries `progress`.
- Covered by 20 commonTest cases including CharGrid validation, short-circuit paths (null / unknown name / oversize / intensity 0), full-intensity replacement, footprint isolation, determinism, partial-intensity stippling distribution, non-mutation, and ASCII snapshots for all six glyphs.

Closes #43

## Test plan
- [x] `./gradlew :phosphor-lumos-cli:jvmTest` (20/20 pass)
- [x] `./gradlew ktlintFormat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)