### PR TITLE
PHO-24/#44 add CliOrb LumosRenderer<LumosTerminalFrame> terminal renderer

### DIFF
--- a/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/ClearMode.kt
+++ b/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/ClearMode.kt
@@ -1,0 +1,15 @@
+package link.socket.phosphor.lumos.cli.renderer
+
+/**
+ * Strategy for clearing the orb region between frames.
+ *
+ * `FULL` rewrites every cell of the orb region every frame, which is simpler
+ * to reason about and tolerant of external programs scribbling over the region
+ * between renders. `DIFFERENTIAL` compares against the previous frame and only
+ * emits cells that changed, which is dramatically cheaper for steady-state
+ * frames but assumes nothing else writes into the orb region.
+ */
+enum class ClearMode {
+    FULL,
+    DIFFERENTIAL,
+}

--- a/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/CliOrb.kt
+++ b/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/CliOrb.kt
@@ -1,0 +1,260 @@
+package link.socket.phosphor.lumos.cli.renderer
+
+import java.io.PrintStream
+import link.socket.phosphor.color.AnsiColorMap
+import link.socket.phosphor.color.AnsiColorMode
+import link.socket.phosphor.color.OklabColor
+import link.socket.phosphor.lumos.LumosRenderTarget
+import link.socket.phosphor.lumos.LumosRenderer
+import link.socket.phosphor.lumos.VoxelFrame
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
+import link.socket.phosphor.lumos.cli.glyph.CliGlyph
+import link.socket.phosphor.lumos.cli.projection.CliLattice
+
+/**
+ * JVM terminal renderer for [LumosTerminalFrame].
+ *
+ * Writes ANSI escape sequences directly to a [PrintStream] (default `System.out`),
+ * completing the Wave 2 pipeline:
+ *
+ * ```
+ * VoxelFrame → CliLattice.project → LumosTerminalFrame
+ *            → CliGlyph.overlay   → LumosTerminalFrame (with glyph)
+ *            → CliOrb.render      → stdout ANSI bytes
+ * ```
+ *
+ * The renderer never blocks on stdin and never installs signal handlers. Resize
+ * detection is polled every [resizePollFrames] renders via the injected
+ * [terminalSize] provider so the implementation works on Unix and Windows JVMs
+ * uniformly.
+ *
+ * [LumosRenderer] is satisfied by overriding `render(VoxelFrame)` to perform
+ * the full projection-and-overlay pipeline internally — useful for embedders
+ * that bind CliOrb directly to a [link.socket.phosphor.runtime.CognitiveSceneRuntime].
+ * Embedders that have already projected (e.g. for snapshot testing) call
+ * `render(LumosTerminalFrame)` instead.
+ *
+ * @param out Destination for ANSI bytes. Defaults to standard output.
+ * @param colorMode Color quantization strategy delegated to [AnsiColorMap].
+ * @param targetFps Informational throttling hint exposed via [preferredFps].
+ *  The renderer itself does not schedule frames; the caller drives [render].
+ * @param clearMode `FULL` rewrites every cell each frame; `DIFFERENTIAL` only
+ *  writes changed cells against the previous frame.
+ * @param terminalSize Provider for the current terminal viewport. Injected
+ *  so tests can drive deterministic resize behavior.
+ * @param resizePollFrames Re-query [terminalSize] every N frames. Set to 0 to
+ *  disable polling entirely (useful in tests that drive resize manually).
+ * @param lattice Optional projection lattice. Required only when callers use
+ *  the [LumosRenderer] interface method `render(VoxelFrame)` directly.
+ */
+class CliOrb(
+    private val out: PrintStream = System.out,
+    private val colorMode: AnsiColorMode = AnsiColorMode.TRUECOLOR,
+    val targetFps: Int = DEFAULT_TARGET_FPS,
+    private val clearMode: ClearMode = ClearMode.DIFFERENTIAL,
+    private val terminalSize: TerminalSize = DefaultTerminalSize(),
+    private val resizePollFrames: Int = DEFAULT_RESIZE_POLL_FRAMES,
+    private val lattice: CliLattice? = null,
+) : LumosRenderer<LumosTerminalFrame> {
+    init {
+        require(targetFps > 0) { "targetFps must be > 0, got $targetFps" }
+        require(resizePollFrames >= 0) {
+            "resizePollFrames must be >= 0, got $resizePollFrames"
+        }
+    }
+
+    override val target: LumosRenderTarget = LumosRenderTarget.VOXEL_TERMINAL
+    override val preferredFps: Int = targetFps
+
+    private var initialized: Boolean = false
+    private var stopped: Boolean = false
+    private var lastFrame: LumosTerminalFrame? = null
+    private var lastSize: TerminalSize.Dimensions? = null
+    private var framesSinceResizeCheck: Int = 0
+    private var shutdownHook: Thread? = null
+
+    /**
+     * Project [frame] via [lattice], overlay any active glyph, then render to
+     * [out]. The projected [LumosTerminalFrame] is returned so callers can
+     * inspect it for tests or downstream consumers.
+     *
+     * Requires a non-null `lattice` constructor argument. If the caller has
+     * already projected, use the [render] overload that accepts a
+     * [LumosTerminalFrame] instead.
+     */
+    override fun render(frame: VoxelFrame): LumosTerminalFrame {
+        val activeLattice =
+            lattice
+                ?: error(
+                    "CliOrb.render(VoxelFrame) requires a CliLattice; either pass one to " +
+                        "the constructor or project externally and call render(LumosTerminalFrame).",
+                )
+        val projected = activeLattice.project(frame)
+        val withGlyph = CliGlyph.overlay(projected)
+        render(withGlyph)
+        return withGlyph
+    }
+
+    /**
+     * Render an already-projected [frame] to [out]. Safe to call repeatedly;
+     * the first call hides the cursor and clears the screen, subsequent calls
+     * follow [clearMode].
+     *
+     * Calls after [stop] are no-ops.
+     */
+    fun render(frame: LumosTerminalFrame) {
+        if (stopped) return
+
+        var forceFull = clearMode == ClearMode.FULL
+        if (!initialized) {
+            out.print(CURSOR_HIDE)
+            out.print(CLEAR_SCREEN)
+            initialized = true
+            lastSize = terminalSize.current()
+            forceFull = true
+        } else if (resizePollFrames > 0 && framesSinceResizeCheck >= resizePollFrames) {
+            framesSinceResizeCheck = 0
+            val now = terminalSize.current()
+            if (now != lastSize) {
+                lastSize = now
+                out.print(CLEAR_SCREEN)
+                forceFull = true
+            }
+        }
+        framesSinceResizeCheck++
+
+        val previousFrame =
+            if (forceFull ||
+                lastFrame?.width != frame.width ||
+                lastFrame?.height != frame.height
+            ) {
+                null
+            } else {
+                lastFrame
+            }
+
+        writeCells(frame, previousFrame)
+        parkCursor(frame)
+        lastFrame = frame
+        out.flush()
+    }
+
+    /**
+     * Begin a render session and install a JVM shutdown hook that calls
+     * [stop]. Calling [start] more than once has no additional effect.
+     */
+    fun start() {
+        if (shutdownHook != null) return
+        val hook = Thread({ stop() }, "CliOrb-shutdown")
+        Runtime.getRuntime().addShutdownHook(hook)
+        shutdownHook = hook
+    }
+
+    /**
+     * Clear the orb region, restore the cursor, and mark this renderer as
+     * stopped so further [render] calls are no-ops. Idempotent.
+     */
+    fun stop() {
+        if (stopped) return
+        stopped = true
+        if (initialized) {
+            out.print(CLEAR_SCREEN)
+            out.print(CURSOR_HOME)
+        }
+        out.print(CURSOR_SHOW)
+        out.print(STYLE_RESET)
+        out.flush()
+
+        val hook = shutdownHook
+        if (hook != null) {
+            shutdownHook = null
+            try {
+                Runtime.getRuntime().removeShutdownHook(hook)
+            } catch (_: IllegalStateException) {
+                // JVM is already shutting down — the hook is running us and
+                // cannot be removed. Safe to ignore.
+            }
+        }
+    }
+
+    private fun writeCells(
+        frame: LumosTerminalFrame,
+        previous: LumosTerminalFrame?,
+    ) {
+        val width = frame.width
+        val height = frame.height
+        if (width == 0 || height == 0) return
+
+        var lastFg: OklabColor? = null
+        var lastBg: OklabColor? = null
+        var lastBold = false
+        var styleEstablished = false
+        var cursorRow = -1
+        var cursorCol = -1
+
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val idx = y * width + x
+                val cell = frame.cells[idx]
+                val prevCell = previous?.cells?.get(idx)
+                if (prevCell != null && prevCell == cell) {
+                    continue
+                }
+
+                if (cursorRow != y || cursorCol != x) {
+                    out.print(cursorMove(y, x))
+                }
+
+                val fgChanged = cell.foreground != lastFg
+                val bgChanged = cell.background != lastBg
+                val boldChanged = cell.bold != lastBold
+                if (!styleEstablished || fgChanged || bgChanged || boldChanged) {
+                    out.print(STYLE_RESET)
+                    if (cell.bold) out.print(STYLE_BOLD)
+                    cell.foreground?.let { out.print(AnsiColorMap.escape(it, colorMode)) }
+                    cell.background?.let {
+                        out.print(AnsiColorMap.backgroundEscape(it, colorMode))
+                    }
+                    lastFg = cell.foreground
+                    lastBg = cell.background
+                    lastBold = cell.bold
+                    styleEstablished = true
+                }
+
+                out.print(cell.char)
+                cursorRow = y
+                cursorCol = x + 1
+            }
+        }
+
+        if (styleEstablished) {
+            out.print(STYLE_RESET)
+        }
+    }
+
+    private fun parkCursor(frame: LumosTerminalFrame) {
+        // Park just below the orb region so the cursor never sits on a visible
+        // cell. Bounded by the current terminal height when known.
+        val viewportRows = lastSize?.rows ?: (frame.height + 1)
+        val parkRow = (frame.height + 1).coerceAtMost(viewportRows).coerceAtLeast(1)
+        out.print(cursorMove(parkRow - 1, 0))
+    }
+
+    private fun cursorMove(
+        row: Int,
+        col: Int,
+    ): String = "${CSI}${row + 1};${col + 1}H"
+
+    companion object {
+        const val DEFAULT_TARGET_FPS: Int = 30
+        const val DEFAULT_RESIZE_POLL_FRAMES: Int = 30
+
+        internal const val CSI: String = "["
+        internal const val CURSOR_HIDE: String = "$CSI?25l"
+        internal const val CURSOR_SHOW: String = "$CSI?25h"
+        internal const val CURSOR_HOME: String = "${CSI}H"
+        internal const val CLEAR_SCREEN: String = "${CSI}2J"
+        internal const val STYLE_RESET: String = "${CSI}0m"
+        internal const val STYLE_BOLD: String = "${CSI}1m"
+    }
+}

--- a/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/TerminalSize.kt
+++ b/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/TerminalSize.kt
@@ -1,0 +1,69 @@
+package link.socket.phosphor.lumos.cli.renderer
+
+/**
+ * Provides the current terminal dimensions to [CliOrb] for resize polling and
+ * orb-region sizing. Abstracted behind an interface so tests can inject fake
+ * dimensions and trigger the resize codepath deterministically.
+ */
+fun interface TerminalSize {
+    fun current(): Dimensions
+
+    /**
+     * Terminal viewport dimensions in character cells.
+     *
+     * @property columns Visible columns (>= 1).
+     * @property rows Visible rows (>= 1).
+     */
+    data class Dimensions(
+        val columns: Int,
+        val rows: Int,
+    ) {
+        init {
+            require(columns >= 1) { "columns must be >= 1, got $columns" }
+            require(rows >= 1) { "rows must be >= 1, got $rows" }
+        }
+    }
+
+    companion object {
+        /** Conservative fallback when no real dimensions can be detected. */
+        val FALLBACK: Dimensions = Dimensions(columns = 80, rows = 24)
+
+        /** Fixed-size provider for tests and headless usage. */
+        fun fixed(
+            columns: Int,
+            rows: Int,
+        ): TerminalSize = TerminalSize { Dimensions(columns, rows) }
+    }
+}
+
+/**
+ * Default JVM [TerminalSize] provider.
+ *
+ * Cross-platform best effort:
+ *  1. Honor explicit `phosphor.term.columns` / `phosphor.term.rows` JVM
+ *     properties when set — useful in tests and headless containers.
+ *  2. Honor `COLUMNS` / `LINES` environment variables when present.
+ *  3. Fall back to [TerminalSize.FALLBACK] (80x24).
+ *
+ * Native terminal queries (TIOCGWINSZ on Unix, GetConsoleScreenBufferInfo on
+ * Windows) are intentionally out of scope: they require either a JNI library
+ * or JLine, which would add a runtime dependency this module avoids. Most
+ * embedders run inside a shell that exports `LINES` and `COLUMNS`, and the
+ * fallback keeps the renderer usable when nothing is exported.
+ */
+class DefaultTerminalSize : TerminalSize {
+    override fun current(): TerminalSize.Dimensions {
+        val cols = readDimension("phosphor.term.columns", "COLUMNS") ?: TerminalSize.FALLBACK.columns
+        val rows = readDimension("phosphor.term.rows", "LINES") ?: TerminalSize.FALLBACK.rows
+        return TerminalSize.Dimensions(columns = cols, rows = rows)
+    }
+
+    private fun readDimension(
+        systemProperty: String,
+        environmentVariable: String,
+    ): Int? {
+        val fromProperty = System.getProperty(systemProperty)?.toIntOrNull()?.takeIf { it >= 1 }
+        if (fromProperty != null) return fromProperty
+        return System.getenv(environmentVariable)?.toIntOrNull()?.takeIf { it >= 1 }
+    }
+}

--- a/phosphor-lumos-cli/src/jvmTest/kotlin/link/socket/phosphor/lumos/cli/renderer/CliOrbTest.kt
+++ b/phosphor-lumos-cli/src/jvmTest/kotlin/link/socket/phosphor/lumos/cli/renderer/CliOrbTest.kt
@@ -1,0 +1,279 @@
+package link.socket.phosphor.lumos.cli.renderer
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import link.socket.phosphor.color.AnsiColorMode
+import link.socket.phosphor.color.NeutralColor
+import link.socket.phosphor.color.OklabColor
+import link.socket.phosphor.lumos.LumosRenderTarget
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
+import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
+
+class CliOrbTest {
+    @Test
+    fun `target and preferredFps expose terminal-render metadata`() {
+        val orb = CliOrb(out = PrintStream(ByteArrayOutputStream()), targetFps = 24)
+        assertEquals(LumosRenderTarget.VOXEL_TERMINAL, orb.target)
+        assertEquals(24, orb.preferredFps)
+    }
+
+    @Test
+    fun `constructor rejects non-positive fps`() {
+        assertFails {
+            CliOrb(out = PrintStream(ByteArrayOutputStream()), targetFps = 0)
+        }
+    }
+
+    @Test
+    fun `constructor rejects negative resize poll interval`() {
+        assertFails {
+            CliOrb(out = PrintStream(ByteArrayOutputStream()), resizePollFrames = -1)
+        }
+    }
+
+    @Test
+    fun `FULL render of a 5x3 frame with one red cell emits cursor hide, clear, and the colored character`() {
+        val buffer = ByteArrayOutputStream()
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                colorMode = AnsiColorMode.TRUECOLOR,
+                clearMode = ClearMode.FULL,
+                terminalSize = TerminalSize.fixed(columns = 20, rows = 10),
+                resizePollFrames = 0,
+            )
+        val cells = MutableList(5 * 3) { TerminalCell() }
+        cells[1 * 5 + 2] = TerminalCell(char = 'R', foreground = RED)
+        val frame = frameOf(width = 5, height = 3, cells = cells)
+
+        orb.render(frame)
+
+        val out = buffer.toString(Charsets.UTF_8)
+        assertTrue(out.startsWith(CURSOR_HIDE + CLEAR_SCREEN), "must start with hide+clear: $out")
+        // Row 2 cursor parking is emitted before the red cell character; the
+        // cursor walks the row left-to-right and prints R at column 3.
+        assertTrue(out.contains("$ESC[2;1H"), "must position cursor at start of red cell row: $out")
+        assertTrue(out.contains("$ESC[38;2;255;0;0m"), "must emit truecolor fg for red: $out")
+        assertTrue(out.contains('R'), "must emit the red cell's character: $out")
+    }
+
+    @Test
+    fun `run-length optimization emits exactly one fg escape for an all-red frame`() {
+        val buffer = ByteArrayOutputStream()
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                colorMode = AnsiColorMode.TRUECOLOR,
+                clearMode = ClearMode.FULL,
+                terminalSize = TerminalSize.fixed(columns = 20, rows = 10),
+                resizePollFrames = 0,
+            )
+        val cells = List(4 * 2) { TerminalCell(char = '#', foreground = RED) }
+        val frame = frameOf(width = 4, height = 2, cells = cells)
+
+        orb.render(frame)
+
+        val out = buffer.toString(Charsets.UTF_8)
+        val fgCount = countOccurrences(out, "$ESC[38;2;")
+        assertEquals(1, fgCount, "expected exactly one fg escape, got $fgCount in: $out")
+    }
+
+    @Test
+    fun `DIFFERENTIAL mode produces no cell writes when frame is unchanged`() {
+        val buffer = ByteArrayOutputStream()
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                colorMode = AnsiColorMode.TRUECOLOR,
+                clearMode = ClearMode.DIFFERENTIAL,
+                terminalSize = TerminalSize.fixed(columns = 20, rows = 10),
+                resizePollFrames = 0,
+            )
+        val cells = List(3 * 2) { TerminalCell(char = '*', foreground = RED) }
+        val frame = frameOf(width = 3, height = 2, cells = cells)
+
+        orb.render(frame)
+        buffer.reset()
+        orb.render(frame)
+
+        val out = buffer.toString(Charsets.UTF_8)
+        // Second render must not emit the cell character or any fg escape.
+        assertFalse(out.contains('*'), "unchanged frame should not rewrite cells: $out")
+        assertFalse(out.contains("$ESC[38;2;"), "unchanged frame should not re-emit color: $out")
+        // Cursor parking is allowed.
+        assertTrue(out.contains("$ESC["), "cursor parking escape should still be emitted: $out")
+    }
+
+    @Test
+    fun `DIFFERENTIAL mode emits only the changed cells on the second frame`() {
+        val buffer = ByteArrayOutputStream()
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                colorMode = AnsiColorMode.TRUECOLOR,
+                clearMode = ClearMode.DIFFERENTIAL,
+                terminalSize = TerminalSize.fixed(columns = 20, rows = 10),
+                resizePollFrames = 0,
+            )
+        val base = List(4 * 2) { TerminalCell(char = '.', foreground = RED) }
+        orb.render(frameOf(width = 4, height = 2, cells = base))
+        buffer.reset()
+
+        val updated = base.toMutableList()
+        updated[1 * 4 + 2] = TerminalCell(char = 'X', foreground = RED)
+        orb.render(frameOf(width = 4, height = 2, cells = updated, frameNumber = 1))
+
+        val out = buffer.toString(Charsets.UTF_8)
+        assertTrue(out.contains("$ESC[2;3H"), "should position cursor at the changed cell: $out")
+        assertTrue(out.contains('X'), "should emit the changed cell character: $out")
+        assertFalse(out.contains('.'), "unchanged cells should not re-emit their character: $out")
+    }
+
+    @Test
+    fun `start registers a shutdown hook that emits cursor show on stop`() {
+        val buffer = ByteArrayOutputStream()
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                terminalSize = TerminalSize.fixed(columns = 20, rows = 10),
+                resizePollFrames = 0,
+            )
+        val frame = frameOf(width = 2, height = 2, cells = List(4) { TerminalCell() })
+
+        orb.start()
+        orb.render(frame)
+        buffer.reset()
+        // Simulate the shutdown hook firing.
+        orb.stop()
+
+        val out = buffer.toString(Charsets.UTF_8)
+        assertTrue(out.contains(CURSOR_SHOW), "stop must emit cursor-show: $out")
+        assertTrue(out.contains(CLEAR_SCREEN), "stop must clear the orb region: $out")
+    }
+
+    @Test
+    fun `render is a no-op after stop`() {
+        val buffer = ByteArrayOutputStream()
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                terminalSize = TerminalSize.fixed(columns = 20, rows = 10),
+                resizePollFrames = 0,
+            )
+        val frame = frameOf(width = 2, height = 2, cells = List(4) { TerminalCell(char = 'A') })
+        orb.render(frame)
+        orb.stop()
+        buffer.reset()
+
+        orb.render(frame)
+
+        val out = buffer.toString(Charsets.UTF_8)
+        assertEquals("", out, "render must be a no-op after stop, got: $out")
+    }
+
+    @Test
+    fun `resize polling forces a full clear and redraw on next frame`() {
+        val buffer = ByteArrayOutputStream()
+        val sizes = mutableListOf(TerminalSize.Dimensions(20, 10), TerminalSize.Dimensions(40, 12))
+        val provider =
+            object : TerminalSize {
+                private var index = 0
+
+                override fun current(): TerminalSize.Dimensions {
+                    val dim = sizes[index.coerceAtMost(sizes.lastIndex)]
+                    if (index < sizes.lastIndex) index++
+                    return dim
+                }
+            }
+        val orb =
+            CliOrb(
+                out = PrintStream(buffer),
+                colorMode = AnsiColorMode.TRUECOLOR,
+                clearMode = ClearMode.DIFFERENTIAL,
+                terminalSize = provider,
+                resizePollFrames = 1,
+            )
+        val cells = List(3 * 2) { TerminalCell(char = '.', foreground = RED) }
+        val frame = frameOf(width = 3, height = 2, cells = cells)
+
+        orb.render(frame)
+        buffer.reset()
+        // Next render polls and sees a new size; must clear and full-redraw.
+        orb.render(frame)
+
+        val out = buffer.toString(Charsets.UTF_8)
+        assertTrue(out.contains(CLEAR_SCREEN), "resize must trigger a clear: $out")
+        assertEquals(
+            cells.size,
+            countOccurrences(out, "."),
+            "every cell must be re-emitted after a resize: $out",
+        )
+    }
+
+    @Test
+    fun `render of VoxelFrame without a lattice fails fast`() {
+        val orb = CliOrb(out = PrintStream(ByteArrayOutputStream()))
+        assertFails { orb.render(MINIMAL_VOXEL_FRAME) }
+    }
+
+    private fun frameOf(
+        width: Int,
+        height: Int,
+        cells: List<TerminalCell>,
+        frameNumber: Long = 0L,
+    ): LumosTerminalFrame =
+        LumosTerminalFrame(
+            width = width,
+            height = height,
+            cells = cells,
+            ambient = null,
+            glyphState = null,
+            frameNumber = frameNumber,
+        )
+
+    private fun countOccurrences(
+        haystack: String,
+        needle: String,
+    ): Int {
+        if (needle.isEmpty()) return 0
+        var count = 0
+        var index = haystack.indexOf(needle)
+        while (index >= 0) {
+            count++
+            index = haystack.indexOf(needle, index + needle.length)
+        }
+        return count
+    }
+
+    companion object {
+        private const val ESC: String = ""
+        private const val CURSOR_HIDE: String = "$ESC[?25l"
+        private const val CURSOR_SHOW: String = "$ESC[?25h"
+        private const val CLEAR_SCREEN: String = "$ESC[2J"
+
+        private val RED: OklabColor = OklabColor.fromSrgb(NeutralColor.fromRgba(1f, 0f, 0f))
+
+        private val MINIMAL_VOXEL_FRAME: link.socket.phosphor.lumos.VoxelFrame =
+            link.socket.phosphor.lumos.VoxelFrame(
+                tick = 0L,
+                timestampEpochMillis = 0L,
+                resolution = 4,
+                cells = emptyList(),
+                ambient =
+                    link.socket.phosphor.lumos.VoxelAmbient(
+                        glowRed = 0f,
+                        glowGreen = 0f,
+                        glowBlue = 0f,
+                        glowIntensity = 0f,
+                        orbRotationX = 0f,
+                        orbRotationY = 0f,
+                        orbRotationZ = 0f,
+                    ),
+            )
+    }
+}

--- a/phosphor-lumos-cli/src/jvmTest/kotlin/link/socket/phosphor/lumos/cli/renderer/TerminalSizeTest.kt
+++ b/phosphor-lumos-cli/src/jvmTest/kotlin/link/socket/phosphor/lumos/cli/renderer/TerminalSizeTest.kt
@@ -1,0 +1,72 @@
+package link.socket.phosphor.lumos.cli.renderer
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TerminalSizeTest {
+    private var savedColumns: String? = null
+    private var savedRows: String? = null
+
+    @BeforeTest
+    fun saveProperties() {
+        savedColumns = System.getProperty(PROPERTY_COLUMNS)
+        savedRows = System.getProperty(PROPERTY_ROWS)
+        System.clearProperty(PROPERTY_COLUMNS)
+        System.clearProperty(PROPERTY_ROWS)
+    }
+
+    @AfterTest
+    fun restoreProperties() {
+        savedColumns?.let { System.setProperty(PROPERTY_COLUMNS, it) }
+            ?: System.clearProperty(PROPERTY_COLUMNS)
+        savedRows?.let { System.setProperty(PROPERTY_ROWS, it) }
+            ?: System.clearProperty(PROPERTY_ROWS)
+    }
+
+    @Test
+    fun `default provider honors system properties when set`() {
+        System.setProperty(PROPERTY_COLUMNS, "120")
+        System.setProperty(PROPERTY_ROWS, "40")
+
+        val dims = DefaultTerminalSize().current()
+
+        assertEquals(120, dims.columns)
+        assertEquals(40, dims.rows)
+    }
+
+    @Test
+    fun `default provider falls back to 80x24 when no signal is available`() {
+        // System properties cleared by BeforeTest; env vars in CI may or may not
+        // be set, so we only assert the fallback when both are absent.
+        val columnsEnv = System.getenv("COLUMNS")?.toIntOrNull()
+        val rowsEnv = System.getenv("LINES")?.toIntOrNull()
+        if (columnsEnv != null || rowsEnv != null) return
+
+        val dims = DefaultTerminalSize().current()
+        assertEquals(TerminalSize.FALLBACK.columns, dims.columns)
+        assertEquals(TerminalSize.FALLBACK.rows, dims.rows)
+    }
+
+    @Test
+    fun `fixed factory returns the injected dimensions`() {
+        val provider = TerminalSize.fixed(columns = 64, rows = 18)
+        val dims = provider.current()
+        assertEquals(64, dims.columns)
+        assertEquals(18, dims.rows)
+    }
+
+    @Test
+    fun `dimensions reject non-positive values`() {
+        assertFailsWith<IllegalArgumentException> { TerminalSize.Dimensions(columns = 0, rows = 24) }
+        assertFailsWith<IllegalArgumentException> { TerminalSize.Dimensions(columns = 80, rows = 0) }
+        assertFailsWith<IllegalArgumentException> { TerminalSize.Dimensions(columns = -1, rows = 24) }
+    }
+
+    companion object {
+        private const val PROPERTY_COLUMNS: String = "phosphor.term.columns"
+        private const val PROPERTY_ROWS: String = "phosphor.term.rows"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CliOrb`, a JVM `LumosRenderer<LumosTerminalFrame>` that writes ANSI escape sequences to a `PrintStream`, completing the Wave 2 pipeline. Supports `FULL` and `DIFFERENTIAL` clear modes with run-length color optimization, cursor hide/show lifecycle, shutdown-hook-driven `start()`/`stop()`, and polled cross-platform resize handling via an injectable `TerminalSize` provider (system props → env vars → 80x24 fallback).
- Includes a `TerminalSize` provider interface and JVM default implementation, plus a `ClearMode` enum.
- Unit tests cover the FULL render output, run-length optimization (one color escape for an all-red frame), `DIFFERENTIAL` no-op on unchanged frames and changed-cell-only emission on subsequent frames, `start()`/`stop()` shutdown semantics, no-op after stop, resize polling triggering a full redraw, and the missing-lattice error path.

Closes #44

## Test plan
- [x] `./gradlew :phosphor-lumos-cli:jvmTest`
- [x] `./gradlew jvmTest ktlintCheck`