### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ kotlin.version=2.3.10
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 #Phosphor
-phosphorVersion=0.4.0
+phosphorVersion=0.5.0


### PR DESCRIPTION
Bumps `phosphorVersion` in `gradle.properties` from `0.4.0` to `0.5.0` to prepare the next release.

This release includes 16 commits since v0.4.0: the new `phosphor-lumos` and `phosphor-lumos-cli` modules, `LumosRenderer`, `VoxelFrame`/`VoxelFrameBuilder`, `CliOrb`/`CliLattice`/`CliGlyph` CLI components, atmosphere choreography, OKLab color system, and voxel sphere primitive.

Pushing the `v0.5.0` tag after merge will trigger CI to publish all three modules to Maven Central and generate a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)