### PR TITLE
PHO-25/#52 add :phosphor-lumos-compose module + LumosCanvasFrame DTO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Compile iOS device target and run simulator tests
-        run: ./gradlew :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64 iosSimulatorArm64Test
+        run: ./gradlew :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64 :phosphor-lumos-compose:compileKotlinIosArm64 iosSimulatorArm64Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Phosphor is a Kotlin Multiplatform rendering library that translates cognitive state into visible light — ASCII luminance, color ramps, particle physics, 3D waveform surfaces, and the Lumos voxel-orb companion visualization. Read [SOUL.md](SOUL.md) for project philosophy and values.
+Phosphor is a Kotlin Multiplatform rendering library that translates cognitive state into visible light — ASCII luminance, color ramps, particle physics, 3D waveform surfaces, and the Lumos voxel-orb companion visualization with Compose Canvas support. Read [SOUL.md](SOUL.md) for project philosophy and values.
 
 ## Development Commands
 
@@ -46,6 +46,7 @@ Phosphor is a layered rendering pipeline: cognitive signals flow in, visible cha
 | `phosphor-core/` | Shared rendering pipeline — signals, fields, palettes, cells, choreography, emitters, and runtime bridges |
 | `phosphor-lumos/` | Framework-free voxel-orb companion visualization for cognitive state, built as a sibling output module over `phosphor-core` |
 | `phosphor-lumos-cli/` | JVM terminal DTO and future CLI renderer surface for projected Lumos voxel frames |
+| `phosphor-lumos-compose/` | Compose Multiplatform DTO and Canvas rendering surface for projected Lumos voxel frames |
 
 ### Future / Aspirational Modules
 
@@ -67,6 +68,8 @@ Phosphor is a layered rendering pipeline: cognitive signals flow in, visible cha
 | `phosphor-lumos/src/commonTest/` | Lumos smoke tests and future voxel-frame API tests |
 | `phosphor-lumos-cli/src/commonMain/` | JVM CLI-facing Lumos terminal frame DTOs |
 | `phosphor-lumos-cli/src/commonTest/` | CLI DTO serialization and shape-contract tests |
+| `phosphor-lumos-compose/src/commonMain/` | Compose Multiplatform Canvas-facing Lumos frame DTOs |
+| `phosphor-lumos-compose/src/commonTest/` | Compose DTO serialization and shape-contract tests |
 
 ## Before You Change Anything
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Signal → Field → Palette → Render → Choreography → Emitter → Surface
 | `:phosphor-core` | Shared rendering pipeline — signals, fields, palettes, cells, choreography, emitters, and runtime bridges |
 | `:phosphor-lumos` | Voxel-orb companion visualization module for cognitive state, scaffolded for downstream Lumos frame APIs |
 | `:phosphor-lumos-cli` | JVM terminal DTO and future CLI renderer surface for projected Lumos voxel frames |
+| `:phosphor-lumos-compose` | Compose Multiplatform DTO and Canvas rendering surface for projected Lumos voxel frames |
 
 ---
 

--- a/phosphor-lumos-compose/build.gradle.kts
+++ b/phosphor-lumos-compose/build.gradle.kts
@@ -1,0 +1,148 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    kotlin("plugin.compose")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.compose")
+}
+
+val phosphorVersion: String by project
+
+group = "link.socket"
+version = phosphorVersion
+
+val hasInMemorySigningCredentials =
+    providers.gradleProperty("signingInMemoryKey").isPresent &&
+        providers.gradleProperty("signingInMemoryKeyId").isPresent &&
+        providers.gradleProperty("signingInMemoryKeyPassword").isPresent
+val hasFileSigningCredentials =
+    providers.gradleProperty("signing.secretKeyRingFile").isPresent &&
+        providers.gradleProperty("signing.keyId").isPresent &&
+        providers.gradleProperty("signing.password").isPresent
+val hasGpgSigningCredentials = providers.gradleProperty("signing.gnupg.keyName").isPresent
+val hasSigningCredentials =
+    hasInMemorySigningCredentials ||
+        hasFileSigningCredentials ||
+        hasGpgSigningCredentials
+val isPublishingToMavenLocal =
+    gradle.startParameter.taskNames.any {
+        it == "publishToMavenLocal" || it.endsWith(":publishToMavenLocal")
+    }
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
+        }
+    }
+
+    js(IR) {
+        browser()
+        binaries.executable()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        binaries.executable()
+    }
+
+    val xcf = XCFramework()
+    val iosTargets = listOf(iosX64(), iosArm64(), iosSimulatorArm64())
+
+    iosTargets.forEach {
+        it.binaries.framework {
+            baseName = "phosphor-lumos-compose"
+            xcf.add(this)
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":phosphor-lumos"))
+                implementation(project(":phosphor-core"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3")
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+            }
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+
+    configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
+
+    coordinates("link.socket", "phosphor-lumos-compose", version.toString())
+
+    pom {
+        name.set("Phosphor Lumos Compose")
+        description.set(
+            "Compose Multiplatform DTOs and Canvas rendering surface for Phosphor's " +
+                "framework-free Lumos voxel-orb visualization.",
+        )
+        url.set("https://github.com/socket-link/phosphor")
+        inceptionYear.set("2026")
+
+        licenses {
+            license {
+                name.set("The Apache Software License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("socket-link")
+                name.set("Socket Link")
+                url.set("https://github.com/socket-link")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/socket-link/phosphor.git")
+            developerConnection.set("scm:git:ssh://git@github.com:socket-link/phosphor.git")
+            url.set("https://github.com/socket-link/phosphor")
+        }
+
+        issueManagement {
+            system.set("GitHub Issues")
+            url.set("https://github.com/socket-link/phosphor/issues")
+        }
+    }
+}
+
+plugins.withId("signing") {
+    extensions.configure<SigningExtension>("signing") {
+        if (hasGpgSigningCredentials) {
+            useGpgCmd()
+        }
+    }
+}
+
+tasks.withType<Sign>().configureEach {
+    enabled = hasSigningCredentials && !isPublishingToMavenLocal
+}

--- a/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/frame/LumosCanvasFrame.kt
+++ b/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/frame/LumosCanvasFrame.kt
@@ -1,0 +1,59 @@
+package link.socket.phosphor.lumos.compose.frame
+
+import kotlinx.serialization.Serializable
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelGlyphState
+
+/**
+ * Serializable 2D projection of a [link.socket.phosphor.lumos.VoxelFrame] shaped for Compose Canvas rendering.
+ *
+ * Differs from [link.socket.phosphor.lumos.cli.LumosTerminalFrame] in coordinate system
+ * (pixel-based, Compose-friendly) and color representation (sRGB, not OKLab). Renderers
+ * can paint [voxels] directly using Compose's `Canvas.drawRect` with sRGB color values.
+ *
+ * @property width Pixel width of the canvas the projector was sized for.
+ * @property height Pixel height of the canvas the projector was sized for.
+ * @property voxels Visible voxels only (zero-scale cells dropped during projection).
+ * @property ambient Per-frame parameters passed through from the source [VoxelFrame]
+ *  for halo and glow rendering.
+ * @property glyph Active glyph state, if any. Passed through for glyph-aware overlay rendering.
+ * @property tick Monotonic frame counter passed through from source frame.
+ */
+@Serializable
+data class LumosCanvasFrame(
+    val width: Int,
+    val height: Int,
+    val voxels: List<CanvasVoxel>,
+    val ambient: VoxelAmbient,
+    val glyph: VoxelGlyphState? = null,
+    val tick: Long,
+) {
+    /**
+     * Projected 2D voxel with rendering parameters suitable for Compose Canvas.
+     *
+     * Pixel coordinates are already aspect-corrected and camera-projected; consumers
+     * paint directly at (screenX, screenY) with radius radiusPx.
+     *
+     * @property screenX X position in canvas pixels (0..width).
+     * @property screenY Y position in canvas pixels (0..height). Y grows downward
+     *  following Compose Canvas convention.
+     * @property radiusPx Half the rect side length in pixels, derived from voxel scale
+     *  and canvas density.
+     * @property red sRGB red channel, 0..1, ready for androidx.compose.ui.graphics.Color(red, green, blue).
+     * @property green sRGB green channel, 0..1.
+     * @property blue sRGB blue channel, 0..1.
+     * @property alpha sRGB alpha channel, 0..1. Defaults to 1.0 if source voxel had null alpha.
+     * @property z Z-depth preserved for painter's-algorithm back-to-front compositing.
+     */
+    @Serializable
+    data class CanvasVoxel(
+        val screenX: Float,
+        val screenY: Float,
+        val radiusPx: Float,
+        val red: Float,
+        val green: Float,
+        val blue: Float,
+        val alpha: Float,
+        val z: Float,
+    )
+}

--- a/phosphor-lumos-compose/src/commonTest/kotlin/link/socket/phosphor/lumos/compose/frame/LumosCanvasFrameTest.kt
+++ b/phosphor-lumos-compose/src/commonTest/kotlin/link/socket/phosphor/lumos/compose/frame/LumosCanvasFrameTest.kt
@@ -1,0 +1,50 @@
+package link.socket.phosphor.lumos.compose.frame
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import link.socket.phosphor.lumos.VoxelAmbient
+
+class LumosCanvasFrameTest {
+    @Test
+    fun testLumosCanvasFrameSerializationRoundTrip() {
+        val voxel =
+            LumosCanvasFrame.CanvasVoxel(
+                screenX = 400f,
+                screenY = 300f,
+                radiusPx = 5f,
+                red = 0.5f,
+                green = 0.5f,
+                blue = 1f,
+                alpha = 1f,
+                z = 0.5f,
+            )
+
+        val ambient =
+            VoxelAmbient(
+                glowRed = 0.2f,
+                glowGreen = 0.3f,
+                glowBlue = 0.4f,
+                glowIntensity = 0.8f,
+                orbRotationX = 0.1f,
+                orbRotationY = 0.2f,
+                orbRotationZ = 0.3f,
+            )
+
+        val frame =
+            LumosCanvasFrame(
+                width = 800,
+                height = 600,
+                voxels = listOf(voxel),
+                ambient = ambient,
+                glyph = null,
+                tick = 0L,
+            )
+
+        val json = Json
+        val serialized = json.encodeToString(LumosCanvasFrame.serializer(), frame)
+        val deserialized = json.decodeFromString(LumosCanvasFrame.serializer(), serialized)
+
+        assertEquals(frame, deserialized)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "Phosphor"
 include(":phosphor-core")
 include(":phosphor-lumos")
 include(":phosphor-lumos-cli")
+include(":phosphor-lumos-compose")
 
 pluginManagement {
     repositories {
@@ -16,9 +17,11 @@ pluginManagement {
 
         kotlin("multiplatform").version(kotlinVersion)
         kotlin("plugin.serialization").version(kotlinVersion)
+        kotlin("plugin.compose").version(kotlinVersion)
         id("org.jlleitschuh.gradle.ktlint").version("12.2.0")
         id("org.jetbrains.dokka").version("2.1.0")
         id("com.vanniktech.maven.publish").version("0.30.0")
+        id("org.jetbrains.compose").version("1.7.0")
     }
 }
 


### PR DESCRIPTION
## Summary

Scaffold the `:phosphor-lumos-compose` module with full Kotlin Multiplatform support for Compose Canvas rendering of Lumos voxel-orb projections.

Define `LumosCanvasFrame` DTO carrying projected 2D voxel data (pixel coordinates, sRGB colors, z-depth) suitable for Compose's `Canvas.drawRect` rendering. All types `@Serializable` for JSON roundtrip support.

Add comprehensive build system integration: KMP setup matching `:phosphor-lumos` targets (jvm, js, wasmJs, ios), Compose Multiplatform plugin, Maven publishing, and CI updates.

## Test Plan

- [x] Module listed in `./gradlew projects` output
- [x] `./gradlew jvmTest` passes (new test verifies serialization roundtrip)
- [x] `./gradlew :phosphor-lumos-compose:compileKotlinIosArm64` succeeds
- [x] `./gradlew ktlintCheck` passes
- [x] Documentation updated (README.md, AGENTS.md)

Closes PHO-25 and fixes #52.