### PR TITLE
PHO-26/#53 add ComposeLattice VoxelFrame → LumosCanvasFrame projection

### DIFF
--- a/phosphor-lumos-compose/build.gradle.kts
+++ b/phosphor-lumos-compose/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+                implementation(project(":phosphor-core"))
             }
         }
     }

--- a/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLattice.kt
+++ b/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLattice.kt
@@ -1,0 +1,119 @@
+package link.socket.phosphor.lumos.compose.projection
+
+import kotlin.math.cos
+import kotlin.math.sin
+import link.socket.phosphor.lumos.VoxelFrame
+import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame
+import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame.CanvasVoxel
+
+/**
+ * Orthographic projection of a [VoxelFrame] to a [LumosCanvasFrame] for Compose Canvas rendering.
+ *
+ * Mirrors [link.socket.phosphor.lumos.cli.projection.CliLattice] with three structural differences:
+ * 1. **No aspect compression** — pixel cells are 1:1, so [aspectRatio] defaults to 1.0.
+ * 2. **No per-cell winner aggregation** — every visible voxel is emitted as its own [CanvasVoxel].
+ *    The output list is unsorted by z. Painter's-algorithm depth sorting is the composable's
+ *    responsibility, keeping this projector pure.
+ * 3. **Orb rotation applied here** — each voxel's `(x, y, z)` lattice position is rotated by
+ *    Euler angles from [link.socket.phosphor.lumos.VoxelAmbient.orbRotationX],
+ *    [link.socket.phosphor.lumos.VoxelAmbient.orbRotationY], and
+ *    [link.socket.phosphor.lumos.VoxelAmbient.orbRotationZ] before projection.
+ *    **Rotation order: X first, then Y, then Z.**
+ *
+ * Input lattice positions are in `[-1, 1]` on all axes, following the same convention as
+ * `CliLattice`. Y is flipped: `y = +1` maps to the top of the canvas (`screenY = 0`).
+ *
+ * @param widthPx Output canvas width in pixels; must be > 0.
+ * @param heightPx Output canvas height in pixels; must be > 0.
+ * @param voxelRadiusPx Base voxel half-size in pixels at `scale = 1.0`; must be > 0.
+ * @param aspectRatio Pixel aspect ratio applied to the Y axis; defaults to 1.0 for square pixels.
+ *  Must be > 0.
+ */
+class ComposeLattice(
+    val widthPx: Int,
+    val heightPx: Int,
+    val voxelRadiusPx: Float = 4f,
+    val aspectRatio: Float = 1.0f,
+) {
+    init {
+        require(widthPx > 0) { "widthPx must be > 0, got $widthPx" }
+        require(heightPx > 0) { "heightPx must be > 0, got $heightPx" }
+        require(voxelRadiusPx > 0f) { "voxelRadiusPx must be > 0, got $voxelRadiusPx" }
+        require(aspectRatio > 0f) { "aspectRatio must be > 0, got $aspectRatio" }
+    }
+
+    /**
+     * Project [frame] to a [LumosCanvasFrame].
+     *
+     * Algorithm:
+     * 1. For each voxel with `scale > 0`, apply Euler XYZ rotation (X → Y → Z) using
+     *    angles from [frame]'s ambient state.
+     * 2. Project the rotated position orthographically:
+     *    `screenX = (rx + 1) * 0.5 * widthPx`
+     *    `screenY = (1 - (ry + 1) * 0.5) * heightPx * (1 / aspectRatio)`
+     * 3. Skip voxels whose projected center falls outside `[0, widthPx) × [0, heightPx)`.
+     * 4. Emit one [CanvasVoxel] per surviving voxel with `radiusPx = voxelRadiusPx * scale`,
+     *    sRGB color forwarded directly, and rotated `z` preserved for depth compositing.
+     *
+     * Ambient and glyph state pass through unchanged.
+     */
+    fun project(frame: VoxelFrame): LumosCanvasFrame {
+        val cells = frame.cells
+        val ambient = frame.ambient
+
+        val cosX = cos(ambient.orbRotationX.toDouble()).toFloat()
+        val sinX = sin(ambient.orbRotationX.toDouble()).toFloat()
+        val cosY = cos(ambient.orbRotationY.toDouble()).toFloat()
+        val sinY = sin(ambient.orbRotationY.toDouble()).toFloat()
+        val cosZ = cos(ambient.orbRotationZ.toDouble()).toFloat()
+        val sinZ = sin(ambient.orbRotationZ.toDouble()).toFloat()
+
+        val invAspect = 1f / aspectRatio
+        val out = ArrayList<CanvasVoxel>(cells.size)
+
+        for (cell in cells) {
+            if (cell.scale <= 0f) continue
+
+            // Rotate around X axis
+            val x1 = cell.x
+            val y1 = cell.y * cosX - cell.z * sinX
+            val z1 = cell.y * sinX + cell.z * cosX
+
+            // Rotate around Y axis
+            val x2 = x1 * cosY + z1 * sinY
+            val y2 = y1
+            val z2 = -x1 * sinY + z1 * cosY
+
+            // Rotate around Z axis
+            val rx = x2 * cosZ - y2 * sinZ
+            val ry = x2 * sinZ + y2 * cosZ
+            val rz = z2
+
+            val screenX = (rx + 1f) * 0.5f * widthPx
+            val screenY = (1f - (ry + 1f) * 0.5f) * heightPx * invAspect
+
+            if (screenX < 0f || screenX >= widthPx || screenY < 0f || screenY >= heightPx) continue
+
+            out +=
+                CanvasVoxel(
+                    screenX = screenX,
+                    screenY = screenY,
+                    radiusPx = voxelRadiusPx * cell.scale,
+                    red = cell.red,
+                    green = cell.green,
+                    blue = cell.blue,
+                    alpha = cell.alpha ?: 1.0f,
+                    z = rz,
+                )
+        }
+
+        return LumosCanvasFrame(
+            width = widthPx,
+            height = heightPx,
+            voxels = out,
+            ambient = ambient,
+            glyph = frame.glyph,
+            tick = frame.tick,
+        )
+    }
+}

--- a/phosphor-lumos-compose/src/commonTest/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLatticeTest.kt
+++ b/phosphor-lumos-compose/src/commonTest/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLatticeTest.kt
@@ -1,0 +1,382 @@
+package link.socket.phosphor.lumos.compose.projection
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import link.socket.phosphor.coordinate.CoordinateSpace
+import link.socket.phosphor.field.SubstrateState
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelCell
+import link.socket.phosphor.lumos.VoxelFrame
+import link.socket.phosphor.lumos.VoxelFrameBuilder
+import link.socket.phosphor.lumos.VoxelGlyphState
+import link.socket.phosphor.palette.AtmospherePresets
+import link.socket.phosphor.runtime.SceneSnapshot
+import link.socket.phosphor.signal.AtmosphereState
+import link.socket.phosphor.signal.CognitivePhase
+
+class ComposeLatticeTest {
+    @Test
+    fun `constructor rejects non-positive dimensions, radius, and aspect ratio`() {
+        assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = 0, heightPx = 600) }
+        assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = -1, heightPx = 600) }
+        assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = 800, heightPx = 0) }
+        assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = 800, heightPx = -1) }
+        assertFailsWith<IllegalArgumentException> {
+            ComposeLattice(widthPx = 800, heightPx = 600, voxelRadiusPx = 0f)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ComposeLattice(widthPx = 800, heightPx = 600, voxelRadiusPx = -1f)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ComposeLattice(widthPx = 800, heightPx = 600, aspectRatio = 0f)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ComposeLattice(widthPx = 800, heightPx = 600, aspectRatio = -1f)
+        }
+        // Valid construction should not throw
+        ComposeLattice(widthPx = 800, heightPx = 600)
+    }
+
+    @Test
+    fun `voxel at origin with no rotation projects to canvas center`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val frame = voxelFrame(cells = listOf(voxelAt(x = 0f, y = 0f, z = 0f)))
+        val canvas = lattice.project(frame)
+
+        assertEquals(1, canvas.voxels.size)
+        val v = canvas.voxels[0]
+        // screenX = (0 + 1) * 0.5 * 400 = 200
+        // screenY = (1 - (0 + 1) * 0.5) * 400 = 200
+        assertNear(200f, v.screenX, "screenX")
+        assertNear(200f, v.screenY, "screenY")
+    }
+
+    @Test
+    fun `voxel at (1,0,0) with no rotation projects to right edge`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val frame = voxelFrame(cells = listOf(voxelAt(x = 1f, y = 0f, z = 0f)))
+        val canvas = lattice.project(frame)
+
+        // screenX = (1 + 1) * 0.5 * 400 = 400 → out of bounds [0, 400)
+        // The voxel lands exactly at widthPx, which is out-of-bounds, so it should be dropped
+        assertEquals(0, canvas.voxels.size, "voxel at x=1 lands at screenX=widthPx and should be dropped")
+    }
+
+    @Test
+    fun `voxel at (-1,0,0) with no rotation projects to left edge`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val frame = voxelFrame(cells = listOf(voxelAt(x = -1f, y = 0f, z = 0f)))
+        val canvas = lattice.project(frame)
+
+        assertEquals(1, canvas.voxels.size)
+        val v = canvas.voxels[0]
+        // screenX = (-1 + 1) * 0.5 * 400 = 0
+        // screenY = (1 - (0 + 1) * 0.5) * 400 = 200
+        assertNear(0f, v.screenX, "screenX")
+        assertNear(200f, v.screenY, "screenY")
+    }
+
+    @Test
+    fun `voxel at (0,1,0) with no rotation projects to top edge (Y-flip)`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val frame = voxelFrame(cells = listOf(voxelAt(x = 0f, y = 1f, z = 0f)))
+        val canvas = lattice.project(frame)
+
+        // screenX = (0 + 1) * 0.5 * 400 = 200
+        // screenY = (1 - (1 + 1) * 0.5) * 400 = 0
+        assertEquals(1, canvas.voxels.size)
+        val v = canvas.voxels[0]
+        assertNear(200f, v.screenX, "screenX")
+        assertNear(0f, v.screenY, "screenY (top edge, Y-flip)")
+    }
+
+    @Test
+    fun `zero-scale voxel is dropped`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val cell = VoxelCell(x = 0f, y = 0f, z = 0f, scale = 0f, red = 1f, green = 1f, blue = 1f)
+        val canvas = lattice.project(voxelFrame(cells = listOf(cell)))
+
+        assertEquals(0, canvas.voxels.size)
+    }
+
+    @Test
+    fun `negative-scale voxel is dropped`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val cell = VoxelCell(x = 0f, y = 0f, z = 0f, scale = -0.1f, red = 1f, green = 1f, blue = 1f)
+        val canvas = lattice.project(voxelFrame(cells = listOf(cell)))
+
+        assertEquals(0, canvas.voxels.size)
+    }
+
+    @Test
+    fun `scale maps to radiusPx and colors are forwarded unchanged`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400, voxelRadiusPx = 8f)
+        val cell =
+            VoxelCell(
+                x = 0f,
+                y = 0f,
+                z = 0f,
+                scale = 0.5f,
+                red = 0.1f,
+                green = 0.2f,
+                blue = 0.3f,
+                alpha = 0.7f,
+            )
+        val canvas = lattice.project(voxelFrame(cells = listOf(cell)))
+
+        assertEquals(1, canvas.voxels.size)
+        val v = canvas.voxels[0]
+        assertNear(4f, v.radiusPx, "radiusPx = voxelRadiusPx * scale = 8 * 0.5")
+        assertNear(0.1f, v.red, "red")
+        assertNear(0.2f, v.green, "green")
+        assertNear(0.3f, v.blue, "blue")
+        assertNear(0.7f, v.alpha, "alpha")
+    }
+
+    @Test
+    fun `null alpha defaults to 1f`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val cell = VoxelCell(x = 0f, y = 0f, z = 0f, scale = 1f, red = 1f, green = 1f, blue = 1f, alpha = null)
+        val canvas = lattice.project(voxelFrame(cells = listOf(cell)))
+
+        assertEquals(1, canvas.voxels.size)
+        assertNear(1.0f, canvas.voxels[0].alpha, "null alpha should default to 1.0")
+    }
+
+    @Test
+    fun `voxel at (1,0,0) with orbRotationY pi over 2 projects near canvas center with negative z`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val ambient = DEFAULT_AMBIENT.copy(orbRotationY = (PI / 2).toFloat())
+        val frame = voxelFrame(cells = listOf(voxelAt(x = 1f, y = 0f, z = 0f)), ambient = ambient)
+        val canvas = lattice.project(frame)
+
+        // After Y rotation of π/2: (1,0,0) → (0,0,-1)
+        // screenX = (0 + 1) * 0.5 * 400 = 200 (center)
+        // screenY = (1 - (0 + 1) * 0.5) * 400 = 200 (center)
+        // rz = -1 (negative z, rotated away from camera)
+        assertEquals(1, canvas.voxels.size)
+        val v = canvas.voxels[0]
+        assertNear(200f, v.screenX, "screenX near center", tolerance = 1f)
+        assertNear(200f, v.screenY, "screenY near center", tolerance = 1f)
+        assertTrue(v.z < 0f, "z should be negative after rotation away from camera, got ${v.z}")
+    }
+
+    @Test
+    fun `identity rotation (all zero angles) produces same output as unrotated projection`() {
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+        val cells =
+            listOf(
+                voxelAt(x = 0.5f, y = 0.5f, z = 0.5f),
+                voxelAt(x = -0.3f, y = 0.2f, z = -0.1f),
+            )
+        val frameNoRotation = voxelFrame(cells = cells, ambient = DEFAULT_AMBIENT)
+        val frameZeroAngles =
+            voxelFrame(
+                cells = cells,
+                ambient = DEFAULT_AMBIENT.copy(orbRotationX = 0f, orbRotationY = 0f, orbRotationZ = 0f),
+            )
+
+        val a = lattice.project(frameNoRotation)
+        val b = lattice.project(frameZeroAngles)
+
+        assertEquals(a.voxels, b.voxels)
+    }
+
+    @Test
+    fun `voxel projected outside canvas bounds is dropped`() {
+        val lattice = ComposeLattice(widthPx = 100, heightPx = 100)
+        // x = 1 maps to screenX = 100 (out of bounds for [0, 100))
+        val cell = voxelAt(x = 1f, y = 0f, z = 0f)
+        val canvas = lattice.project(voxelFrame(cells = listOf(cell)))
+
+        assertEquals(0, canvas.voxels.size)
+    }
+
+    @Test
+    fun `ambient and glyph state pass through unchanged`() {
+        val ambient =
+            VoxelAmbient(
+                glowRed = 0.1f,
+                glowGreen = 0.2f,
+                glowBlue = 0.3f,
+                glowIntensity = 0.4f,
+                orbRotationX = 0f,
+                orbRotationY = 0f,
+                orbRotationZ = 0f,
+            )
+        val glyph =
+            VoxelGlyphState(
+                glyphName = "CHECK",
+                progress = 0.4f,
+                red = 0.9f,
+                green = 0.8f,
+                blue = 0.7f,
+            )
+        val frame = voxelFrame(tick = 42L, cells = emptyList(), ambient = ambient, glyph = glyph)
+        val canvas = ComposeLattice(widthPx = 400, heightPx = 400).project(frame)
+
+        assertEquals(ambient, canvas.ambient)
+        assertEquals(glyph, canvas.glyph)
+        assertEquals(42L, canvas.tick)
+        assertEquals(400, canvas.width)
+        assertEquals(400, canvas.height)
+    }
+
+    @Test
+    fun `projection is deterministic for identical inputs`() {
+        val frame = settledFrame(AtmospherePresets.IDLE)
+        val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
+
+        val a = lattice.project(frame)
+        val b = lattice.project(frame)
+
+        assertEquals(a.voxels, b.voxels)
+        assertEquals(a.ambient, b.ambient)
+    }
+
+    @Test
+    fun `IDLE atmosphere snapshot at 400x400 matches baseline voxel count and centroid`() {
+        assertSnapshot(AtmospherePresets.IDLE, IDLE_BASELINE)
+    }
+
+    @Test
+    fun `LISTENING atmosphere snapshot at 400x400 matches baseline voxel count and centroid`() {
+        assertSnapshot(AtmospherePresets.LISTENING, LISTENING_BASELINE)
+    }
+
+    @Test
+    fun `THINKING atmosphere snapshot at 400x400 matches baseline voxel count and centroid`() {
+        assertSnapshot(AtmospherePresets.THINKING, THINKING_BASELINE)
+    }
+
+    @Test
+    fun `UNCERTAIN atmosphere snapshot at 400x400 matches baseline voxel count and centroid`() {
+        assertSnapshot(AtmospherePresets.UNCERTAIN, UNCERTAIN_BASELINE)
+    }
+
+    @Test
+    fun `READY atmosphere snapshot at 400x400 matches baseline voxel count and centroid`() {
+        assertSnapshot(AtmospherePresets.READY, READY_BASELINE)
+    }
+
+    private fun assertSnapshot(
+        atmosphere: AtmosphereState,
+        baseline: SnapshotBaseline,
+    ) {
+        val frame = settledFrame(atmosphere)
+        val canvas = ComposeLattice(widthPx = 400, heightPx = 400).project(frame)
+        val count = canvas.voxels.size
+        val centroidX = if (count > 0) canvas.voxels.sumOf { it.screenX.toDouble() }.toFloat() / count else 0f
+        val centroidY = if (count > 0) canvas.voxels.sumOf { it.screenY.toDouble() }.toFloat() / count else 0f
+
+        assertEquals(
+            baseline.voxelCount,
+            count,
+            "voxel count mismatch for ${atmosphere::class.simpleName}",
+        )
+        assertNear(baseline.centroidX, centroidX, "centroidX", tolerance = 1f)
+        assertNear(baseline.centroidY, centroidY, "centroidY", tolerance = 1f)
+    }
+
+    private fun settledFrame(atmosphere: AtmosphereState): VoxelFrame {
+        val builder = VoxelFrameBuilder(initialResolution = atmosphere.resolution)
+        val snapshot =
+            SceneSnapshot(
+                frameIndex = 0L,
+                elapsedTimeSeconds = 0f,
+                coordinateSpace = CoordinateSpace.WORLD_CENTERED,
+                agentStates = emptyList(),
+                substrateState = SubstrateState.create(2, 2),
+                particleStates = emptyList(),
+                flowConnections = emptyList(),
+                flowField = null,
+                waveformHeightField = null,
+                waveformGridWidth = null,
+                waveformGridDepth = null,
+                cameraTransform = null,
+                emitterStates = emptyList(),
+                choreographyPhase = CognitivePhase.NONE,
+                atmosphere = atmosphere,
+                atmosphereTransition = null,
+            )
+        var frame = builder.build(snapshot, dt = 0f)
+        repeat(SETTLE_FRAMES) {
+            frame = builder.build(snapshot, dt = SETTLE_DT)
+        }
+        return frame
+    }
+
+    private fun voxelFrame(
+        tick: Long = 0L,
+        cells: List<VoxelCell>,
+        ambient: VoxelAmbient = DEFAULT_AMBIENT,
+        glyph: VoxelGlyphState? = null,
+    ): VoxelFrame =
+        VoxelFrame(
+            tick = tick,
+            timestampEpochMillis = 0L,
+            resolution = 10,
+            cells = cells,
+            ambient = ambient,
+            glyph = glyph,
+        )
+
+    private fun voxelAt(
+        x: Float,
+        y: Float,
+        z: Float,
+    ): VoxelCell =
+        VoxelCell(
+            x = x,
+            y = y,
+            z = z,
+            scale = 1f,
+            red = 1f,
+            green = 1f,
+            blue = 1f,
+        )
+
+    private fun assertNear(
+        expected: Float,
+        actual: Float,
+        label: String,
+        tolerance: Float = 0.01f,
+    ) {
+        assertTrue(
+            abs(expected - actual) <= tolerance,
+            "$label: expected $expected ± $tolerance, got $actual",
+        )
+    }
+
+    private data class SnapshotBaseline(val voxelCount: Int, val centroidX: Float, val centroidY: Float)
+
+    companion object {
+        private val DEFAULT_AMBIENT =
+            VoxelAmbient(
+                glowRed = 0f,
+                glowGreen = 0f,
+                glowBlue = 0f,
+                glowIntensity = 0f,
+                orbRotationX = 0f,
+                orbRotationY = 0f,
+                orbRotationZ = 0f,
+            )
+
+        private const val SETTLE_FRAMES: Int = 60
+        private const val SETTLE_DT: Float = 0.05f
+
+        // Baselines committed after first run. Centroid tolerance: ±1px.
+        private val IDLE_BASELINE = SnapshotBaseline(voxelCount = 4638, centroidX = 199.95895f, centroidY = 199.7617f)
+        private val LISTENING_BASELINE =
+            SnapshotBaseline(voxelCount = 4610, centroidX = 201.17964f, centroidY = 200.50601f)
+        private val THINKING_BASELINE =
+            SnapshotBaseline(voxelCount = 4568, centroidX = 202.3864f, centroidY = 200.70616f)
+        private val UNCERTAIN_BASELINE =
+            SnapshotBaseline(voxelCount = 4597, centroidX = 199.00285f, centroidY = 199.86017f)
+        private val READY_BASELINE = SnapshotBaseline(voxelCount = 4614, centroidX = 201.32152f, centroidY = 199.20158f)
+    }
+}

--- a/phosphor-lumos-compose/src/commonTest/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLatticeTest.kt
+++ b/phosphor-lumos-compose/src/commonTest/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLatticeTest.kt
@@ -20,7 +20,7 @@ import link.socket.phosphor.signal.CognitivePhase
 
 class ComposeLatticeTest {
     @Test
-    fun `constructor rejects non-positive dimensions, radius, and aspect ratio`() {
+    fun `constructor rejects non-positive dimensions and radius and aspect ratio`() {
         assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = 0, heightPx = 600) }
         assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = -1, heightPx = 600) }
         assertFailsWith<IllegalArgumentException> { ComposeLattice(widthPx = 800, heightPx = 0) }
@@ -56,7 +56,7 @@ class ComposeLatticeTest {
     }
 
     @Test
-    fun `voxel at (1,0,0) with no rotation projects to right edge`() {
+    fun `voxel at 1 0 0 with no rotation projects to right edge`() {
         val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
         val frame = voxelFrame(cells = listOf(voxelAt(x = 1f, y = 0f, z = 0f)))
         val canvas = lattice.project(frame)
@@ -67,7 +67,7 @@ class ComposeLatticeTest {
     }
 
     @Test
-    fun `voxel at (-1,0,0) with no rotation projects to left edge`() {
+    fun `voxel at neg1 0 0 with no rotation projects to left edge`() {
         val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
         val frame = voxelFrame(cells = listOf(voxelAt(x = -1f, y = 0f, z = 0f)))
         val canvas = lattice.project(frame)
@@ -81,7 +81,7 @@ class ComposeLatticeTest {
     }
 
     @Test
-    fun `voxel at (0,1,0) with no rotation projects to top edge (Y-flip)`() {
+    fun `voxel at 0 1 0 with no rotation projects to top edge Y-flip`() {
         val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
         val frame = voxelFrame(cells = listOf(voxelAt(x = 0f, y = 1f, z = 0f)))
         val canvas = lattice.project(frame)
@@ -148,7 +148,7 @@ class ComposeLatticeTest {
     }
 
     @Test
-    fun `voxel at (1,0,0) with orbRotationY pi over 2 projects near canvas center with negative z`() {
+    fun `voxel at 1 0 0 with orbRotationY pi over 2 projects near canvas center with negative z`() {
         val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
         val ambient = DEFAULT_AMBIENT.copy(orbRotationY = (PI / 2).toFloat())
         val frame = voxelFrame(cells = listOf(voxelAt(x = 1f, y = 0f, z = 0f)), ambient = ambient)
@@ -166,7 +166,7 @@ class ComposeLatticeTest {
     }
 
     @Test
-    fun `identity rotation (all zero angles) produces same output as unrotated projection`() {
+    fun `identity rotation with all zero angles produces same output as unrotated projection`() {
         val lattice = ComposeLattice(widthPx = 400, heightPx = 400)
         val cells =
             listOf(


### PR DESCRIPTION
Implements `ComposeLattice`, the Compose-side orthographic projector that turns a `VoxelFrame` into a `LumosCanvasFrame` for Canvas rendering. Mirrors `CliLattice` with three key differences: Euler XYZ orb rotation is applied here (not in the terminal path), every visible voxel is emitted as its own `CanvasVoxel` (no per-cell winner logic), and aspect ratio defaults to 1.0 for square pixels. Adds 19 unit tests covering constructor validation, cardinal projection corners, rotation, color forwarding, and five atmosphere snapshot baselines at 400×400.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)