### PR TITLE
[codex] Include Lumos Compose in Maven publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run tests before publish
-        run: ./gradlew :phosphor-core:jvmTest :phosphor-lumos:jvmTest :phosphor-lumos-cli:jvmTest :phosphor-core:compileKotlinIosArm64 :phosphor-lumos:compileKotlinIosArm64
+        run: >
+          ./gradlew
+          :phosphor-core:jvmTest
+          :phosphor-lumos:jvmTest
+          :phosphor-lumos-cli:jvmTest
+          :phosphor-lumos-compose:jvmTest
+          :phosphor-core:compileKotlinIosArm64
+          :phosphor-lumos:compileKotlinIosArm64
+          :phosphor-lumos-compose:compileKotlinIosArm64
 
       - name: Decode signing key
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -64,13 +72,21 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey="$(cat /tmp/signing-key.asc)"
-          ./gradlew :phosphor-core:publishAllPublicationsToMavenCentralRepository :phosphor-lumos:publishAllPublicationsToMavenCentralRepository :phosphor-lumos-cli:publishAllPublicationsToMavenCentralRepository
+          ./gradlew \
+            :phosphor-core:publishAllPublicationsToMavenCentralRepository \
+            :phosphor-lumos:publishAllPublicationsToMavenCentralRepository \
+            :phosphor-lumos-cli:publishAllPublicationsToMavenCentralRepository \
+            :phosphor-lumos-compose:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           echo "Dry run mode - publishing to Maven Local only"
-          ./gradlew :phosphor-core:publishToMavenLocal :phosphor-lumos:publishToMavenLocal :phosphor-lumos-cli:publishToMavenLocal
+          ./gradlew \
+            :phosphor-core:publishToMavenLocal \
+            :phosphor-lumos:publishToMavenLocal \
+            :phosphor-lumos-cli:publishToMavenLocal \
+            :phosphor-lumos-compose:publishToMavenLocal
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
This PR updates the Maven Central publish workflow to include `phosphor-lumos-compose` in pre-publish JVM and iOS checks, real Maven Central publishing, and dry-run local publishing. The root cause was that the module had its own publication tasks but the release workflow only invoked core, lumos, and lumos-cli tasks. I authored the commit as Codex so the patch is not attributed to the user. Validated with `./gradlew ktlintFormat`, `./gradlew jvmTest`, `./gradlew :phosphor-lumos-compose:publishToMavenLocal`, and `git diff --check`.