### PR TITLE
[codex] Bump release version to 0.6.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ kotlin.version=2.3.10
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 #Phosphor
-phosphorVersion=0.6.0
+phosphorVersion=0.6.1


### PR DESCRIPTION
This PR bumps `phosphorVersion` from `0.6.0` to `0.6.1` so the next release can publish a new Maven Central version that includes the newly added `phosphor-lumos-compose` artifact. I authored the commit as Codex so the version bump is not attributed to the user. Validated with `./gradlew ktlintFormat`, `./gradlew jvmTest`, and `git diff --check`.