### PR TITLE
PHO-28/#61 rename CognitivePhase.EVALUATE → LEARN, add OBSERVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to Phosphor are documented in this file.
+
+## [Unreleased]
+
+### Breaking Changes
+
+#### `CognitivePhase` enum updated to canonical PROPEL vocabulary
+
+**`EVALUATE` renamed to `LEARN`** — The reflection phase is now named `LEARN` to match the canonical six-phase PROPEL model (`PERCEIVE / RECALL / OBSERVE / PLAN / EXECUTE / LEARN`).
+
+**`OBSERVE` added** — A new phase between `RECALL` and `PLAN` representing pattern recognition (comparing input against retrieved context). Its visual ramp mirrors `PERCEIVE` (cool blues → white), consistent with the Wave 3 default mapping in AMPERE and Lumos.
+
+**Final enum order:** `PERCEIVE, RECALL, OBSERVE, PLAN, EXECUTE, LEARN, LOOP, NONE`
+
+`LOOP` and `NONE` are preserved — they are Phosphor-internal phases used by the cell-based renderer's scheduling and do not map to PROPEL directly.
+
+#### Migration path for consumers
+
+| Before | After |
+|--------|-------|
+| `CognitivePhase.EVALUATE` | `CognitivePhase.LEARN` |
+| (absent) | `CognitivePhase.OBSERVE` |
+
+Steps:
+1. Bump your Phosphor dependency to this version.
+2. Rename all `CognitivePhase.EVALUATE` references to `CognitivePhase.LEARN`.
+3. Add `OBSERVE` branches to any exhaustive `when (phase: CognitivePhase)` expressions. The Kotlin compiler will surface every site that needs touching.
+4. If you bridge to AMPERE's `CognitivePhase`, remove any `EVALUATE → LEARN` paveover now that both enums use canonical names.
+
+#### Notes on the AMPERE coexistence
+
+Phosphor's `link.socket.phosphor.signal.CognitivePhase` and AMPERE's `link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase` are separate enums that coexist by design. This release aligns Phosphor's vocabulary with the canonical PROPEL model that AMPERE already uses; downstream AMPERE cleanup (walking the seven files identified in the Wave 4 recon) is tracked separately.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Each cognitive phase has a distinct visual texture. The eye reads the shift inst
 |-------|-----------|------------|
 | PERCEIVE | Sparse, circular, floating (` ·∙.:∘○◌◯`) | Cool blues → white |
 | RECALL | Warm, solid, crystallizing (` .·*✦⬡◆●`) | Dark amber → warm gold |
+| OBSERVE | Sparse, scanning, circular (` ·∙.·:∘○◌◯`) | Cool blues → white |
 | PLAN | Structured, branching, grid-like (` ░▒▓│├┤┬┴┼`) | Teal → cyan |
 | EXECUTE | Dense, aggressive, lightning (` .:;+=*#%@█⚡`) | Red → yellow → white |
-| EVALUATE | Diffuse, reflective, fading (` .·:*∘○◌`) | Purple → dim lavender |
+| LEARN | Diffuse, reflective, fading (` .·:*∘○◌`) | Purple → dim lavender |
 
 ---
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -100,9 +100,10 @@ If both point to the same word, that's the name. If they diverge, prefer the ter
 |-------|---------------|------------|
 | PERCEIVE | Sparse, circular, floating (` ·∙.:∘○◌◯`) | Cool blues → white |
 | RECALL | Warm, solid, crystallizing (` .·*✦⬡◆●`) | Dark amber → warm gold |
+| OBSERVE | Sparse, scanning, circular (` ·∙.·:∘○◌◯`) | Cool blues → white |
 | PLAN | Structured, branching, grid-like (` ░▒▓│├┤┬┴┼`) | Teal → cyan |
 | EXECUTE | Dense, aggressive, lightning (` .:;+=*#%@█⚡`) | Red → yellow → white |
-| EVALUATE | Diffuse, reflective, fading (` .·:*∘○◌`) | Purple → dim lavender |
+| LEARN | Diffuse, reflective, fading (` .·:*∘○◌`) | Purple → dim lavender |
 
 ### Principles
 

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/choreography/CognitiveChoreographer.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/choreography/CognitiveChoreographer.kt
@@ -26,7 +26,8 @@ import link.socket.phosphor.signal.CognitivePhase
  * - RECALL: Existing particles near agent brighten and cluster (memory activation)
  * - PLAN: Particles form tentative structures, testing arrangements (strategy formation)
  * - EXECUTE: Particles align and accelerate outward (discharge/committed action)
- * - EVALUATE: Particles slow, some fade, some persist as new anchors (reflection)
+ * - OBSERVE: Particles slow and spread, gentle outward drift (pattern recognition)
+ * - LEARN: Particles slow, some fade, some persist as new anchors (reflection)
  * - LOOP: Brief stillness, then subtle pulse (cycle reset)
  *
  * The choreographer observes phase transitions on agents and orchestrates particle
@@ -68,8 +69,8 @@ class CognitiveChoreographer(
         /** Radius for LOOP despawn area */
         private const val LOOP_DESPAWN_RADIUS = 3f
 
-        /** Radius for EVALUATE fade effect */
-        private const val EVALUATE_FADE_RADIUS = 10f
+        /** Radius for LEARN/OBSERVE fade effect */
+        private const val LEARN_FADE_RADIUS = 10f
 
         /** Particle count per PERCEIVE stream direction */
         private const val PERCEIVE_PARTICLES_PER_DIR = 2
@@ -154,8 +155,8 @@ class CognitiveChoreographer(
             spawnSparkBurst(agent.position, TRANSITION_SPARK_COUNT)
         }
 
-        // EXECUTE → EVALUATE: Trail particles along the executed flow connection
-        if (from == CognitivePhase.EXECUTE && to == CognitivePhase.EVALUATE) {
+        // EXECUTE → LEARN: Trail particles along the executed flow connection
+        if (from == CognitivePhase.EXECUTE && to == CognitivePhase.LEARN) {
             spawnTrailFromAgent(agent.position)
         }
 
@@ -180,9 +181,10 @@ class CognitiveChoreographer(
         return when (phase) {
             CognitivePhase.PERCEIVE -> applyPerceive(agent, substrate, deltaTime)
             CognitivePhase.RECALL -> applyRecall(agent, substrate, deltaTime)
+            CognitivePhase.OBSERVE -> applyObserve(agent, substrate, deltaTime)
             CognitivePhase.PLAN -> applyPlan(agent, substrate, deltaTime)
             CognitivePhase.EXECUTE -> applyExecute(agent, substrate, deltaTime)
-            CognitivePhase.EVALUATE -> applyEvaluate(agent, substrate, deltaTime)
+            CognitivePhase.LEARN -> applyLearn(agent, substrate, deltaTime)
             CognitivePhase.LOOP -> applyLoop(agent, substrate, deltaTime)
             CognitivePhase.NONE -> substrate
         }
@@ -243,7 +245,7 @@ class CognitiveChoreographer(
             particles.getParticlesNear(
                 agent.position.x.roundToInt(),
                 agent.position.y.roundToInt(),
-                radius = EVALUATE_FADE_RADIUS,
+                radius = LEARN_FADE_RADIUS,
             )
         nearbyParticles.forEach { p ->
             p.life = (p.life + 0.3f * deltaTime).coerceAtMost(1f)
@@ -352,9 +354,38 @@ class CognitiveChoreographer(
         )
     }
 
-    // ── EVALUATE: Afterglow, particles slow and persist (reflection) ──
+    // ── OBSERVE: Pattern recognition, gentle outward drift ──
 
-    private fun applyEvaluate(
+    private fun applyObserve(
+        agent: AgentVisualState,
+        substrate: SubstrateState,
+        deltaTime: Float,
+    ): SubstrateState {
+        // Gentle outward drift of nearby particles (spreading awareness)
+        val nearbyParticles =
+            particles.getParticlesNear(
+                agent.position.x.roundToInt(),
+                agent.position.y.roundToInt(),
+                radius = LEARN_FADE_RADIUS,
+            )
+        nearbyParticles.forEach { p ->
+            p.life = (p.life + 0.1f * deltaTime).coerceAtMost(1f)
+        }
+
+        // Substrate: subtle ripple outward (attention scanning)
+        val center = Point(agent.position.x.roundToInt(), agent.position.y.roundToInt())
+        return substrateAnimator.ripple(
+            state = substrate,
+            center = center,
+            phase = 0.05f,
+            maxRadius = 6f,
+            intensity = 0.15f,
+        )
+    }
+
+    // ── LEARN: Afterglow, particles slow and persist (reflection) ──
+
+    private fun applyLearn(
         agent: AgentVisualState,
         substrate: SubstrateState,
         deltaTime: Float,
@@ -364,7 +395,7 @@ class CognitiveChoreographer(
             particles.getParticlesNear(
                 agent.position.x.roundToInt(),
                 agent.position.y.roundToInt(),
-                radius = EVALUATE_FADE_RADIUS,
+                radius = LEARN_FADE_RADIUS,
             )
         nearbyParticles.forEach { p ->
             // Slow particles down (drag effect)

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/CognitiveColorModel.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/color/CognitiveColorModel.kt
@@ -45,9 +45,10 @@ object CognitiveColorModel {
         mapOf(
             CognitivePhase.PERCEIVE to phaseRamp(listOf(17, 18, 24, 31, 38, 74, 110, 117, 153, 189, 231)),
             CognitivePhase.RECALL to phaseRamp(listOf(52, 94, 130, 136, 172, 178, 214, 220, 221)),
+            CognitivePhase.OBSERVE to phaseRamp(listOf(17, 18, 24, 31, 38, 74, 110, 117, 153, 189, 231)),
             CognitivePhase.PLAN to phaseRamp(listOf(23, 29, 30, 36, 37, 43, 79, 115, 159)),
             CognitivePhase.EXECUTE to phaseRamp(listOf(52, 88, 124, 160, 196, 202, 208, 214, 220, 226, 231)),
-            CognitivePhase.EVALUATE to phaseRamp(listOf(53, 54, 91, 97, 134, 140, 141, 183, 189)),
+            CognitivePhase.LEARN to phaseRamp(listOf(53, 54, 91, 97, 134, 140, 141, 183, 189)),
             CognitivePhase.LOOP to phaseRamp(listOf(232, 236, 240, 244, 248, 252, 255)),
             CognitivePhase.NONE to phaseRamp(listOf(232, 236, 240, 244, 248, 252, 255)),
         )

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/palette/AsciiLuminancePalette.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/palette/AsciiLuminancePalette.kt
@@ -177,11 +177,18 @@ data class AsciiLuminancePalette(
                 name = "execute",
             )
 
-        /** Diffuse, reflective — for EVALUATE phase (afterglow, fading) */
-        val EVALUATE =
+        /** Sparse, circular — for OBSERVE phase (pattern recognition, perception-adjacent) */
+        val OBSERVE =
+            AsciiLuminancePalette(
+                characters = " \u00B7\u2219.\u00B7:\u2218\u25CB\u25CC\u25EF",
+                name = "observe",
+            )
+
+        /** Diffuse, reflective — for LEARN phase (afterglow, fading) */
+        val LEARN =
             AsciiLuminancePalette(
                 characters = " .\u00B7:*\u2218\u25CB\u25CC ",
-                name = "evaluate",
+                name = "learn",
             )
     }
 }

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/palette/CognitiveColorRamp.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/palette/CognitiveColorRamp.kt
@@ -79,6 +79,9 @@ data class CognitiveColorRamp(
         /** Dark amber -> warm gold (memory, warmth) */
         val RECALL = fromModel(CognitivePhase.RECALL)
 
+        /** Cool blues -> white (perception-adjacent, pattern recognition) */
+        val OBSERVE = fromModel(phase = CognitivePhase.OBSERVE, modelPhase = CognitivePhase.PERCEIVE)
+
         /** Teal -> cyan (structured, deliberate) */
         val PLAN = fromModel(CognitivePhase.PLAN)
 
@@ -86,7 +89,7 @@ data class CognitiveColorRamp(
         val EXECUTE = fromModel(CognitivePhase.EXECUTE)
 
         /** Purple -> dim lavender (reflection, settling) */
-        val EVALUATE = fromModel(CognitivePhase.EVALUATE)
+        val LEARN = fromModel(CognitivePhase.LEARN)
 
         /** Neutral gray ramp for LOOP/NONE phases */
         val NEUTRAL = fromModel(phase = CognitivePhase.NONE, modelPhase = CognitivePhase.NONE)
@@ -98,9 +101,10 @@ data class CognitiveColorRamp(
             when (phase) {
                 CognitivePhase.PERCEIVE -> PERCEIVE
                 CognitivePhase.RECALL -> RECALL
+                CognitivePhase.OBSERVE -> OBSERVE
                 CognitivePhase.PLAN -> PLAN
                 CognitivePhase.EXECUTE -> EXECUTE
-                CognitivePhase.EVALUATE -> EVALUATE
+                CognitivePhase.LEARN -> LEARN
                 CognitivePhase.LOOP -> NEUTRAL
                 CognitivePhase.NONE -> NEUTRAL
             }

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/render/PhaseBlender.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/render/PhaseBlender.kt
@@ -12,7 +12,7 @@ import link.socket.phosphor.signal.CognitivePhase
  *
  * When two agents in different phases are near each other, the palette
  * blends at the boundary -- you can see EXECUTE's hot discharge meeting
- * EVALUATE's cool afterglow as a gradient in character density and color.
+ * LEARN's cool afterglow as a gradient in character density and color.
  *
  * @param influenceRadius Maximum distance (in world units) at which an agent
  *        affects the palette selection. Beyond this, returns null (use fallback).
@@ -79,9 +79,10 @@ class PhaseBlender(
             when (phase) {
                 CognitivePhase.PERCEIVE -> AsciiLuminancePalette.PERCEIVE
                 CognitivePhase.RECALL -> AsciiLuminancePalette.RECALL
+                CognitivePhase.OBSERVE -> AsciiLuminancePalette.OBSERVE
                 CognitivePhase.PLAN -> AsciiLuminancePalette.PLAN
                 CognitivePhase.EXECUTE -> AsciiLuminancePalette.EXECUTE
-                CognitivePhase.EVALUATE -> AsciiLuminancePalette.EVALUATE
+                CognitivePhase.LEARN -> AsciiLuminancePalette.LEARN
                 CognitivePhase.LOOP -> AsciiLuminancePalette.STANDARD
                 CognitivePhase.NONE -> AsciiLuminancePalette.STANDARD
             }

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/signal/CognitivePhase.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/signal/CognitivePhase.kt
@@ -3,6 +3,13 @@ package link.socket.phosphor.signal
 /**
  * Cognitive phases from the PROPEL loop.
  * Each phase maps to a distinct visual choreography.
+ *
+ * Canonical PROPEL order: PERCEIVE → RECALL → OBSERVE → PLAN → EXECUTE → LEARN.
+ * LOOP and NONE are Phosphor-internal phases that do not map to PROPEL directly;
+ * they serve the cell-based renderer's internal scheduling.
+ *
+ * Note: this enum is distinct from `link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase`
+ * in the AMPERE project. The two enums coexist by design and are kept in sync at the vocabulary level.
  */
 enum class CognitivePhase {
     /** Gathering sensory input — particles drift inward */
@@ -11,6 +18,9 @@ enum class CognitivePhase {
     /** Memory activation — warm embers brightening */
     RECALL,
 
+    /** Pattern recognition — comparing input against retrieved context */
+    OBSERVE,
+
     /** Strategy formation — tentative structures testing formations */
     PLAN,
 
@@ -18,7 +28,7 @@ enum class CognitivePhase {
     EXECUTE,
 
     /** Reflection — afterglow, particles slow and persist */
-    EVALUATE,
+    LEARN,
 
     /** Cycle complete — brief stillness before next iteration */
     LOOP,

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/timeline/CognitiveDemoTimeline.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/timeline/CognitiveDemoTimeline.kt
@@ -15,7 +15,7 @@ import link.socket.phosphor.signal.CognitivePhase
  * 2. Spark transitions to RECALL (memory activation)
  * 3. Spark enters PLAN, Jazz spawns (strategy + delegation)
  * 4. Jazz enters EXECUTE (committed action)
- * 5. Both enter EVALUATE (reflection)
+ * 5. Both enter LEARN (reflection)
  * 6. Cycle completes
  *
  * Suitable for recording the demo GIF showing "you can watch AI think."
@@ -91,10 +91,10 @@ object CognitiveDemoTimeline {
                 }
             }
 
-            phase("evaluate", 2.0) {
+            phase("learn", 2.0) {
                 onStart {
-                    agents.updateAgentCognitivePhase("spark", CognitivePhase.EVALUATE)
-                    agents.updateAgentCognitivePhase("jazz", CognitivePhase.EVALUATE)
+                    agents.updateAgentCognitivePhase("spark", CognitivePhase.LEARN)
+                    agents.updateAgentCognitivePhase("jazz", CognitivePhase.LEARN)
                 }
             }
 
@@ -116,7 +116,7 @@ object CognitiveDemoTimeline {
             "recall",
             "plan-and-delegate",
             "execute",
-            "evaluate",
+            "learn",
             "complete",
         )
 

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/timeline/WaveformDemoTimeline.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/timeline/WaveformDemoTimeline.kt
@@ -29,7 +29,7 @@ import link.socket.phosphor.signal.CognitivePhase
  *    EXECUTE palette (red to yellow to white). Dense characters, high energy.
  * 7. **Completion** (2s): Task completes. Confetti at both agents.
  *    Surface gradually settles.
- * 8. **Reflection** (2s): EVALUATE phase. EVALUATE palette (purple, diffuse).
+ * 8. **Reflection** (2s): LEARN phase. LEARN palette (purple, diffuse).
  *    Surface returns to gentle undulation. Camera continues orbiting.
  *
  * Suitable for recording the demo GIF showing the 3D cognitive waveform in action.
@@ -244,19 +244,19 @@ object WaveformDemoTimeline {
                 }
             }
 
-            // Phase 8: Reflection — EVALUATE palette, surface returns to gentle undulation
+            // Phase 8: Reflection — LEARN palette, surface returns to gentle undulation
             phase("reflection", 2.0) {
                 onStart {
-                    agents.updateAgentCognitivePhase("spark", CognitivePhase.EVALUATE)
-                    agents.updateAgentCognitivePhase("jazz", CognitivePhase.EVALUATE)
+                    agents.updateAgentCognitivePhase("spark", CognitivePhase.LEARN)
+                    agents.updateAgentCognitivePhase("jazz", CognitivePhase.LEARN)
                     agents.updateAgentState("spark", AgentActivityState.IDLE)
                     agents.updateAgentState("jazz", AgentActivityState.IDLE)
-                    // ColorWash with EVALUATE palette (purple, diffuse)
+                    // ColorWash with LEARN palette (purple, diffuse)
                     emitters.emit(
                         EmitterEffect.ColorWash(
                             duration = 2.0f,
                             radius = 12f,
-                            colorRamp = CognitiveColorRamp.EVALUATE,
+                            colorRamp = CognitiveColorRamp.LEARN,
                             waveFrontSpeed = 4f,
                         ),
                         Vector3(

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/choreography/CognitiveChoreographerTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/choreography/CognitiveChoreographerTest.kt
@@ -173,7 +173,7 @@ class CognitiveChoreographerTest {
     }
 
     @Test
-    fun `EVALUATE slows particles and creates anchors`() {
+    fun `LEARN slows particles and creates anchors`() {
         val (choreographer, particles, _) = createChoreographer()
         val substrate = SubstrateState.create(40, 20)
 
@@ -187,19 +187,19 @@ class CognitiveChoreographerTest {
         choreographer.update(executeAgents, substrate, 0.1f)
         assertTrue(particles.count > 0)
 
-        // Transition to EVALUATE
+        // Transition to LEARN
         val evaluateAgents =
             createAgentLayer(
                 40,
                 20,
-                Triple("agent-1", Vector2(20f, 10f), CognitivePhase.EVALUATE),
+                Triple("agent-1", Vector2(20f, 10f), CognitivePhase.LEARN),
             )
         choreographer.update(evaluateAgents, substrate, 0.1f)
 
         // Some particles should now have attractors (anchored)
         val anchored = particles.getParticles().filter { it.attractor != null }
         // At least some high-life particles get anchored
-        assertTrue(particles.count > 0, "EVALUATE should not despawn all particles")
+        assertTrue(particles.count > 0, "LEARN should not despawn all particles")
     }
 
     @Test

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/color/CognitiveColorModelTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/color/CognitiveColorModelTest.kt
@@ -43,9 +43,10 @@ class CognitiveColorModelTest {
             mapOf(
                 CognitivePhase.PERCEIVE to listOf(17, 18, 24, 31, 38, 74, 110, 117, 153, 189, 231),
                 CognitivePhase.RECALL to listOf(52, 94, 130, 136, 172, 178, 214, 220, 221),
+                CognitivePhase.OBSERVE to listOf(17, 18, 24, 31, 38, 74, 110, 117, 153, 189, 231),
                 CognitivePhase.PLAN to listOf(23, 29, 30, 36, 37, 43, 79, 115, 159),
                 CognitivePhase.EXECUTE to listOf(52, 88, 124, 160, 196, 202, 208, 214, 220, 226, 231),
-                CognitivePhase.EVALUATE to listOf(53, 54, 91, 97, 134, 140, 141, 183, 189),
+                CognitivePhase.LEARN to listOf(53, 54, 91, 97, 134, 140, 141, 183, 189),
                 CognitivePhase.LOOP to listOf(232, 236, 240, 244, 248, 252, 255),
                 CognitivePhase.NONE to listOf(232, 236, 240, 244, 248, 252, 255),
             )

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/palette/AsciiLuminancePaletteTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/palette/AsciiLuminancePaletteTest.kt
@@ -97,9 +97,10 @@ class AsciiLuminancePaletteTest {
                 AsciiLuminancePalette.STANDARD,
                 AsciiLuminancePalette.PERCEIVE,
                 AsciiLuminancePalette.RECALL,
+                AsciiLuminancePalette.OBSERVE,
                 AsciiLuminancePalette.PLAN,
                 AsciiLuminancePalette.EXECUTE,
-                AsciiLuminancePalette.EVALUATE,
+                AsciiLuminancePalette.LEARN,
             )
         palettes.forEach { palette ->
             assertTrue(

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/palette/CognitiveColorRampTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/palette/CognitiveColorRampTest.kt
@@ -57,7 +57,7 @@ class CognitiveColorRampTest {
                 CognitiveColorRamp.RECALL,
                 CognitiveColorRamp.PLAN,
                 CognitiveColorRamp.EXECUTE,
-                CognitiveColorRamp.EVALUATE,
+                CognitiveColorRamp.LEARN,
                 CognitiveColorRamp.NEUTRAL,
             )
         ramps.forEach { ramp ->
@@ -74,7 +74,7 @@ class CognitiveColorRampTest {
         assertEquals(CognitivePhase.RECALL, CognitiveColorRamp.forPhase(CognitivePhase.RECALL).phase)
         assertEquals(CognitivePhase.PLAN, CognitiveColorRamp.forPhase(CognitivePhase.PLAN).phase)
         assertEquals(CognitivePhase.EXECUTE, CognitiveColorRamp.forPhase(CognitivePhase.EXECUTE).phase)
-        assertEquals(CognitivePhase.EVALUATE, CognitiveColorRamp.forPhase(CognitivePhase.EVALUATE).phase)
+        assertEquals(CognitivePhase.LEARN, CognitiveColorRamp.forPhase(CognitivePhase.LEARN).phase)
     }
 
     @Test
@@ -99,7 +99,7 @@ class CognitiveColorRampTest {
                 CognitiveColorRamp.RECALL,
                 CognitiveColorRamp.PLAN,
                 CognitiveColorRamp.EXECUTE,
-                CognitiveColorRamp.EVALUATE,
+                CognitiveColorRamp.LEARN,
                 CognitiveColorRamp.NEUTRAL,
             )
         allRamps.forEach { ramp ->

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/render/AsciiCellTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/render/AsciiCellTest.kt
@@ -116,7 +116,7 @@ class AsciiCellTest {
                 normalX = 0f,
                 normalY = 0f,
                 palette = AsciiLuminancePalette.STANDARD,
-                colorRamp = CognitiveColorRamp.EVALUATE,
+                colorRamp = CognitiveColorRamp.LEARN,
             )
         assertNull(cell.bgColor)
     }

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/render/PhaseBlenderTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/render/PhaseBlenderTest.kt
@@ -166,7 +166,7 @@ class PhaseBlenderTest {
         assertEquals(AsciiLuminancePalette.RECALL, PhaseBlender.paletteForPhase(CognitivePhase.RECALL))
         assertEquals(AsciiLuminancePalette.PLAN, PhaseBlender.paletteForPhase(CognitivePhase.PLAN))
         assertEquals(AsciiLuminancePalette.EXECUTE, PhaseBlender.paletteForPhase(CognitivePhase.EXECUTE))
-        assertEquals(AsciiLuminancePalette.EVALUATE, PhaseBlender.paletteForPhase(CognitivePhase.EVALUATE))
+        assertEquals(AsciiLuminancePalette.LEARN, PhaseBlender.paletteForPhase(CognitivePhase.LEARN))
         assertEquals(AsciiLuminancePalette.STANDARD, PhaseBlender.paletteForPhase(CognitivePhase.LOOP))
         assertEquals(AsciiLuminancePalette.STANDARD, PhaseBlender.paletteForPhase(CognitivePhase.NONE))
     }

--- a/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/timeline/WaveformDemoTimelineTest.kt
+++ b/phosphor-core/src/commonTest/kotlin/link/socket/phosphor/timeline/WaveformDemoTimelineTest.kt
@@ -163,7 +163,7 @@ class WaveformDemoTimelineTest {
     }
 
     @Test
-    fun `reflection phase sets EVALUATE cognitive phase`() {
+    fun `reflection phase sets LEARN cognitive phase`() {
         val (agents, flow, emitters) = createComponents()
         val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
 
@@ -174,8 +174,8 @@ class WaveformDemoTimelineTest {
         // Fire reflection onStart
         timeline.phases[7].onStart?.invoke()
 
-        assertEquals(CognitivePhase.EVALUATE, agents.getAgent("spark")?.cognitivePhase)
-        assertEquals(CognitivePhase.EVALUATE, agents.getAgent("jazz")?.cognitivePhase)
+        assertEquals(CognitivePhase.LEARN, agents.getAgent("spark")?.cognitivePhase)
+        assertEquals(CognitivePhase.LEARN, agents.getAgent("jazz")?.cognitivePhase)
     }
 
     @Test


### PR DESCRIPTION
Aligns Phosphor's `CognitivePhase` enum with the canonical six-phase PROPEL model. `EVALUATE` is renamed to `LEARN` and `OBSERVE` is inserted between `RECALL` and `PLAN`, matching the canonical order: `PERCEIVE / RECALL / OBSERVE / PLAN / EXECUTE / LEARN`. All internal `when` exhaustiveness sites, color/palette mappings, timelines, and tests are updated accordingly. A `CHANGELOG.md` entry documents the breaking change and migration path for consumers.

This is the Phosphor-side change called out by the CLI bridge comment at `AmperePhosphorBridge.kt:59-63`; the AMPERE-side cleanup (walking the seven affected files) is a separate follow-up ticket.

Closes #61

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>