### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ kotlin.version=2.3.10
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 #Phosphor
-phosphorVersion=0.6.1
+phosphorVersion=0.6.2


### PR DESCRIPTION
Increments the project version from 0.6.1 to 0.6.2.

This is a straightforward version bump in gradle.properties.