### PR TITLE
Fix Dokka link resolution warnings and add CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Verify formatting
         run: ./gradlew ktlintCheck
 
+      - name: Generate documentation and check for Dokka warnings
+        run: |
+          ./gradlew dokkaHtml 2>&1 | tee dokka-output.log
+          if grep -q "Couldn't resolve link" dokka-output.log; then
+            echo "❌ Dokka link resolution warnings found:"
+            grep "Couldn't resolve link" dokka-output.log
+            exit 1
+          fi
+          echo "✓ No Dokka link resolution warnings found"
+
   ios:
     name: iOS Compile And Test
     runs-on: macos-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,20 @@ jobs:
           :phosphor-lumos:compileKotlinIosArm64
           :phosphor-lumos-compose:compileKotlinIosArm64
 
+      - name: Check documentation for Dokka warnings
+        run: |
+          ./gradlew \
+            :phosphor-core:dokkaGeneratePublicationHtml \
+            :phosphor-lumos:dokkaGeneratePublicationHtml \
+            :phosphor-lumos-cli:dokkaGeneratePublicationHtml \
+            :phosphor-lumos-compose:dokkaGeneratePublicationHtml 2>&1 | tee dokka-output.log
+          if grep -q "Couldn't resolve link" dokka-output.log; then
+            echo "❌ Dokka link resolution warnings found:"
+            grep "Couldn't resolve link" dokka-output.log
+            exit 1
+          fi
+          echo "✓ No Dokka link resolution warnings found"
+
       - name: Decode signing key
         if: ${{ github.event.inputs.dry_run != 'true' }}
         env:

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/coordinate/CoordinateSpace.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/coordinate/CoordinateSpace.kt
@@ -7,7 +7,7 @@ import link.socket.phosphor.math.Vector3
  * Defines the two coordinate spaces used by Phosphor's rendering pipeline.
  *
  * - [WORLD_CENTERED]: Origin at center of the world. Coordinates range from
- *   `-size/2` to `+size/2`. Used by [CognitiveWaveform.worldPosition] and
+ *   `-size/2` to `+size/2`. Used by the waveform's worldPosition query and
  *   the 3D camera/projection pipeline.
  *
  * - [WORLD_POSITIVE]: Origin at the corner (minimum). Coordinates range from

--- a/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/render/WaveformRasterizer.kt
+++ b/phosphor-core/src/commonMain/kotlin/link/socket/phosphor/render/WaveformRasterizer.kt
@@ -42,7 +42,7 @@ class WaveformRasterizer(
      * @param camera Current camera position/orientation
      * @param palette The character palette to use (phase-specific)
      * @param colorRamp The color ramp to use (phase-specific)
-     * @return 2D array of AsciiCells [row][col], screenHeight rows x screenWidth cols
+     * @return 2D array of AsciiCells, screenHeight rows x screenWidth cols
      */
     fun rasterize(
         waveform: CognitiveWaveform,
@@ -123,7 +123,7 @@ class WaveformRasterizer(
      * @param agents Agent layer for phase lookup
      * @param fallbackPalette Palette for regions with no nearby agents
      * @param fallbackRamp Color ramp for regions with no nearby agents
-     * @return 2D array of AsciiCells [row][col]
+     * @return 2D array of AsciiCells, screenHeight rows x screenWidth cols
      */
     fun rasterizeBlended(
         waveform: CognitiveWaveform,

--- a/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/projection/CliLattice.kt
+++ b/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/projection/CliLattice.kt
@@ -8,7 +8,7 @@ import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
 import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
 
 /**
- * Orthographic projection of a [VoxelFrame] to a [LumosTerminalFrame].
+ * Orthographic projection of a VoxelFrame to a [LumosTerminalFrame].
  *
  * Each voxel's `(x, y)` lattice position maps to a character cell, ignoring
  * `z` for placement but using `z` for occlusion priority (closer voxels win
@@ -19,7 +19,7 @@ import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
  * Orthographic, not perspective: at typical terminal resolutions (40x20 to
  * 60x30) foreshortening barely reads and the simpler projection halves the
  * code volume. Color quantization is deliberately not done here — the
- * winning voxel's sRGB triplet is forwarded as [OklabColor] for the renderer
+ * winning voxel's sRGB triplet is forwarded as OklabColor for the renderer
  * (CliOrb / AnsiColorMap) to quantize.
  *
  * The projection is pure: it allocates one [LumosTerminalFrame] plus two
@@ -55,7 +55,7 @@ class CliLattice(
      *    orthographic mapping of normalized lattice position.
      * 2. Per cell, keep the voxel with the largest `z` (closest to camera).
      * 3. Map each winning voxel's scale to a luminance-ramp character and
-     *    pass its sRGB color through as [OklabColor].
+     *    pass its sRGB color through as OklabColor.
      * 4. Empty cells become transparent blanks.
      *
      * Ambient and glyph state pass through unchanged.

--- a/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/frame/LumosCanvasFrame.kt
+++ b/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/frame/LumosCanvasFrame.kt
@@ -5,11 +5,11 @@ import link.socket.phosphor.lumos.VoxelAmbient
 import link.socket.phosphor.lumos.VoxelGlyphState
 
 /**
- * Serializable 2D projection of a [link.socket.phosphor.lumos.VoxelFrame] shaped for Compose Canvas rendering.
+ * Serializable 2D projection of a [VoxelFrame] shaped for Compose Canvas rendering.
  *
- * Differs from [link.socket.phosphor.lumos.cli.LumosTerminalFrame] in coordinate system
- * (pixel-based, Compose-friendly) and color representation (sRGB, not OKLab). Renderers
- * can paint [voxels] directly using Compose's `Canvas.drawRect` with sRGB color values.
+ * Differs from LumosTerminalFrame in coordinate system (pixel-based, Compose-friendly)
+ * and color representation (sRGB, not OKLab). Renderers can paint [voxels] directly
+ * using Compose's `Canvas.drawRect` with sRGB color values.
  *
  * @property width Pixel width of the canvas the projector was sized for.
  * @property height Pixel height of the canvas the projector was sized for.

--- a/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLattice.kt
+++ b/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLattice.kt
@@ -9,19 +9,18 @@ import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame.CanvasVoxel
 /**
  * Orthographic projection of a [VoxelFrame] to a [LumosCanvasFrame] for Compose Canvas rendering.
  *
- * Mirrors [link.socket.phosphor.lumos.cli.projection.CliLattice] with three structural differences:
+ * Mirrors CliLattice with three structural differences:
  * 1. **No aspect compression** — pixel cells are 1:1, so [aspectRatio] defaults to 1.0.
  * 2. **No per-cell winner aggregation** — every visible voxel is emitted as its own [CanvasVoxel].
  *    The output list is unsorted by z. Painter's-algorithm depth sorting is the composable's
  *    responsibility, keeping this projector pure.
  * 3. **Orb rotation applied here** — each voxel's `(x, y, z)` lattice position is rotated by
- *    Euler angles from [link.socket.phosphor.lumos.VoxelAmbient.orbRotationX],
- *    [link.socket.phosphor.lumos.VoxelAmbient.orbRotationY], and
- *    [link.socket.phosphor.lumos.VoxelAmbient.orbRotationZ] before projection.
+ *    Euler angles from the [VoxelAmbient.orbRotationX], [VoxelAmbient.orbRotationY], and
+ *    [VoxelAmbient.orbRotationZ] properties before projection.
  *    **Rotation order: X first, then Y, then Z.**
  *
  * Input lattice positions are in `[-1, 1]` on all axes, following the same convention as
- * `CliLattice`. Y is flipped: `y = +1` maps to the top of the canvas (`screenY = 0`).
+ * CliLattice. Y is flipped: `y = +1` maps to the top of the canvas (`screenY = 0`).
  *
  * @param widthPx Output canvas width in pixels; must be > 0.
  * @param heightPx Output canvas height in pixels; must be > 0.


### PR DESCRIPTION
## Summary
Fixed unresolvable Dokka documentation links and added CI steps to catch documentation warnings in the future. Cross-module links are converted to plain text descriptions since Dokka cannot resolve links across different published modules.

## Changes
- **Documentation fixes**: Resolved unresolvable links in phosphor-core, phosphor-lumos-cli, and phosphor-lumos-compose modules
- **CI checks**: Added documentation generation and validation steps to both CI and publish workflows to fail the build on link resolution warnings

This ensures documentation quality remains high and prevents publishing releases with broken documentation links.