### PR TITLE
Add phosphor-trace: versioned VoxelFrame recording format with CBOR+gzip codec

### DIFF
--- a/phosphor-trace/build.gradle.kts
+++ b/phosphor-trace/build.gradle.kts
@@ -1,0 +1,131 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+}
+
+val phosphorVersion: String by project
+
+group = "link.socket"
+version = phosphorVersion
+
+val hasInMemorySigningCredentials =
+    providers.gradleProperty("signingInMemoryKey").isPresent &&
+        providers.gradleProperty("signingInMemoryKeyId").isPresent &&
+        providers.gradleProperty("signingInMemoryKeyPassword").isPresent
+val hasFileSigningCredentials =
+    providers.gradleProperty("signing.secretKeyRingFile").isPresent &&
+        providers.gradleProperty("signing.keyId").isPresent &&
+        providers.gradleProperty("signing.password").isPresent
+val hasGpgSigningCredentials = providers.gradleProperty("signing.gnupg.keyName").isPresent
+val hasSigningCredentials =
+    hasInMemorySigningCredentials ||
+        hasFileSigningCredentials ||
+        hasGpgSigningCredentials
+val isPublishingToMavenLocal =
+    gradle.startParameter.taskNames.any {
+        it == "publishToMavenLocal" || it.endsWith(":publishToMavenLocal")
+    }
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
+        }
+    }
+
+    val xcf = XCFramework()
+    val iosTargets = listOf(iosX64(), iosArm64(), iosSimulatorArm64())
+
+    iosTargets.forEach {
+        it.binaries.framework {
+            baseName = "phosphor-trace"
+            xcf.add(this)
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":phosphor-lumos"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.7.3")
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+
+    configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
+
+    coordinates("link.socket", "phosphor-trace", version.toString())
+
+    pom {
+        name.set("Phosphor Trace")
+        description.set(
+            "Kotlin Multiplatform recorded-trace format for Phosphor voxel frames — " +
+                "versioned VoxelTrace, segments, and a CBOR + gzip codec.",
+        )
+        url.set("https://github.com/socket-link/phosphor")
+        inceptionYear.set("2025")
+
+        licenses {
+            license {
+                name.set("The Apache Software License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("socket-link")
+                name.set("Socket Link")
+                url.set("https://github.com/socket-link")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/socket-link/phosphor.git")
+            developerConnection.set("scm:git:ssh://git@github.com:socket-link/phosphor.git")
+            url.set("https://github.com/socket-link/phosphor")
+        }
+
+        issueManagement {
+            system.set("GitHub Issues")
+            url.set("https://github.com/socket-link/phosphor/issues")
+        }
+    }
+}
+
+plugins.withId("signing") {
+    extensions.configure<SigningExtension>("signing") {
+        if (hasGpgSigningCredentials) {
+            useGpgCmd()
+        }
+    }
+}
+
+tasks.withType<Sign>().configureEach {
+    enabled = hasSigningCredentials && !isPublishingToMavenLocal
+}

--- a/phosphor-trace/src/commonMain/kotlin/link/socket/phosphor/trace/TraceCodec.kt
+++ b/phosphor-trace/src/commonMain/kotlin/link/socket/phosphor/trace/TraceCodec.kt
@@ -1,0 +1,97 @@
+package link.socket.phosphor.trace
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.cbor.Cbor
+
+/**
+ * Typed failure modes returned by [TraceCodec.decode].
+ *
+ * Decoding follows the house Result pattern: [TraceCodec.decode] never throws,
+ * it returns a [Result] whose failure cause is one of these.
+ */
+sealed class TraceDecodeError(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause) {
+    /**
+     * The payload could not be un-gzipped or parsed as a [VoxelTrace] — it is
+     * truncated, not a `.vxt` payload, or otherwise corrupt.
+     */
+    class Corrupt(
+        message: String,
+        cause: Throwable?,
+    ) : TraceDecodeError(message, cause)
+
+    /**
+     * The payload parsed but declares a [foundVersion] this build does not
+     * support. The version field exists precisely so newer formats are rejected
+     * cleanly rather than silently misread.
+     */
+    class UnsupportedFormatVersion(
+        val foundVersion: Int,
+        val supportedVersion: Int,
+    ) : TraceDecodeError(
+            "Unsupported trace formatVersion=$foundVersion (this build reads v$supportedVersion)",
+        )
+}
+
+/**
+ * Round-trip serialization for [VoxelTrace]: CBOR for a compact binary encoding,
+ * gzip for the payload, a versioned header, and Result-typed decoding.
+ *
+ * Encoded traces use the `.vxt` file extension ([FILE_EXTENSION]).
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object TraceCodec {
+    /** File extension for an encoded trace payload. */
+    const val FILE_EXTENSION: String = "vxt"
+
+    /** The single [VoxelTrace.formatVersion] this build can decode. */
+    const val SUPPORTED_FORMAT_VERSION: Int = VoxelTrace.CURRENT_FORMAT_VERSION
+
+    private val cbor = Cbor { ignoreUnknownKeys = true }
+
+    /** Encode [trace] to a gzip-compressed CBOR `.vxt` payload. */
+    fun encode(trace: VoxelTrace): ByteArray {
+        val payload = cbor.encodeToByteArray(VoxelTrace.serializer(), trace)
+        return gzipCompress(payload)
+    }
+
+    /**
+     * Decode a `.vxt` payload produced by [encode].
+     *
+     * @return [Result.success] with the trace, or [Result.failure] carrying a
+     *  [TraceDecodeError]: [TraceDecodeError.UnsupportedFormatVersion] when the
+     *  header declares an unknown version, or [TraceDecodeError.Corrupt] when the
+     *  bytes cannot be un-gzipped or parsed.
+     */
+    fun decode(bytes: ByteArray): Result<VoxelTrace> {
+        val trace =
+            try {
+                val payload = gzipDecompress(bytes)
+                cbor.decodeFromByteArray(VoxelTrace.serializer(), payload)
+            } catch (error: Throwable) {
+                return Result.failure(
+                    TraceDecodeError.Corrupt("Failed to decode VoxelTrace payload", error),
+                )
+            }
+
+        if (trace.formatVersion != SUPPORTED_FORMAT_VERSION) {
+            return Result.failure(
+                TraceDecodeError.UnsupportedFormatVersion(trace.formatVersion, SUPPORTED_FORMAT_VERSION),
+            )
+        }
+        return Result.success(trace)
+    }
+}
+
+/**
+ * Compress [data] to a standard gzip (RFC 1952) stream.
+ *
+ * Platform actuals must emit interchangeable gzip framing so a trace encoded on
+ * one platform decodes on another (bundled assets cross JVM and Apple targets).
+ */
+internal expect fun gzipCompress(data: ByteArray): ByteArray
+
+/** Inflate a standard gzip (RFC 1952) stream produced by [gzipCompress]. */
+internal expect fun gzipDecompress(data: ByteArray): ByteArray

--- a/phosphor-trace/src/commonMain/kotlin/link/socket/phosphor/trace/TraceSegment.kt
+++ b/phosphor-trace/src/commonMain/kotlin/link/socket/phosphor/trace/TraceSegment.kt
@@ -1,0 +1,34 @@
+package link.socket.phosphor.trace
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A named, replayable slice of a [VoxelTrace] frame stream.
+ *
+ * Segments carve a recorded trace into the cognitive beats a player loops over.
+ * Names follow the convention consumed downstream by `TraceStateMachine`: a
+ * resting beat is `"idle"`, an active beat is `"thinking"`, and a transition
+ * between two beats is written with an arrow, `"idle→thinking"`.
+ *
+ * @property name Segment label, e.g. `"idle"`, `"thinking"`, `"idle→thinking"`.
+ * @property startFrame Index of the first frame in the segment, inclusive. Must be `>= 0`.
+ * @property endFrame Index of the last frame in the segment, inclusive. Must be `>= startFrame`.
+ * @property loop Whether a player should loop this segment rather than play it once.
+ */
+@Serializable
+data class TraceSegment(
+    val name: String,
+    val startFrame: Int,
+    val endFrame: Int,
+    val loop: Boolean = false,
+) {
+    init {
+        require(startFrame >= 0) { "startFrame must be >= 0, was $startFrame" }
+        require(endFrame >= startFrame) {
+            "endFrame ($endFrame) must be >= startFrame ($startFrame)"
+        }
+    }
+
+    /** Number of frames covered by this segment, inclusive of both endpoints. */
+    val frameCount: Int get() = endFrame - startFrame + 1
+}

--- a/phosphor-trace/src/commonMain/kotlin/link/socket/phosphor/trace/VoxelTrace.kt
+++ b/phosphor-trace/src/commonMain/kotlin/link/socket/phosphor/trace/VoxelTrace.kt
@@ -1,0 +1,290 @@
+package link.socket.phosphor.trace
+
+import kotlinx.serialization.Serializable
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelCell
+import link.socket.phosphor.lumos.VoxelFrame
+import link.socket.phosphor.lumos.VoxelGlyphState
+
+/**
+ * The static lattice descriptor carried once in a [VoxelTrace] header.
+ *
+ * This is deliberately minimal. The Phosphor rest lattice (per-voxel rest
+ * position, unit direction, jitter) lives in `:phosphor-core`'s `VoxelSphere`
+ * and is **not** reproduced here: the recorded unit is `VoxelFrame`, whose
+ * `VoxelCell` positions are already transformed per frame (noise, surface bump,
+ * breath pulse, Y-squash), so a frame recorder cannot recover the rest lattice
+ * without coupling to a specific producer. The only datum that is genuinely
+ * static across a recording is its lattice [resolution].
+ *
+ * @property resolution Lattice resolution shared by every frame in the trace.
+ */
+@Serializable
+data class StaticLattice(
+    val resolution: Int,
+)
+
+/**
+ * A recorded `VoxelFrame` sequence plus the metadata needed to replay, segment,
+ * and audit it — the foundational contract of the Phosphor trace pipeline.
+ *
+ * The format is **columnar**: a small header followed by per-frame dynamic
+ * channel arrays. Every mutable `VoxelCell` attribute is concatenated across all
+ * frames into its own primitive array (all x's, then all y's, and so on), which
+ * groups same-channel bytes so the codec's gzip pass compresses them far better
+ * than an interleaved array-of-structs would. Per-frame cell counts are stored
+ * explicitly because a producer may omit voxels frame-to-frame, so `cells.size`
+ * is not constant.
+ *
+ * The format is **versioned from v1** via [formatVersion]; lossy compression
+ * tricks (quantization, inter-frame deltas) are reserved for a later version and
+ * the field exists so a decoder can reject payloads it does not understand.
+ *
+ * Build one from captured frames with [fromFrames] and project it back to a
+ * `VoxelFrame` list with [toFrames]; serialize it with `TraceCodec`.
+ *
+ * @property formatVersion Format version of this trace. v1 is full-precision columnar CBOR + gzip.
+ * @property fps Frames per second the trace was captured at.
+ * @property frameCount Number of frames in the trace.
+ * @property phosphorVersion Phosphor library version that produced the trace.
+ * @property seed Deterministic seed of the producer, recorded for reproducible replays.
+ * @property paramSnapshot Serialized tuning parameters active during capture, as key/value pairs.
+ * @property staticLattice Lattice geometry that is constant across the recording.
+ * @property segments Named, replayable slices of the frame stream.
+ * @property createdAtEpochMs Wall-clock creation time of the trace, epoch milliseconds.
+ * @property ticks Per-frame monotonic frame counter, length [frameCount].
+ * @property timestampsEpochMillis Per-frame wall-clock timestamp, length [frameCount].
+ * @property cellCounts Per-frame cell count, length [frameCount]. Sums to the channel-array length.
+ * @property cellX Concatenated per-cell x positions across all frames.
+ * @property cellY Concatenated per-cell y positions across all frames.
+ * @property cellZ Concatenated per-cell z positions across all frames.
+ * @property cellScale Concatenated per-cell scale multipliers across all frames.
+ * @property cellRed Concatenated per-cell red channel across all frames.
+ * @property cellGreen Concatenated per-cell green channel across all frames.
+ * @property cellBlue Concatenated per-cell blue channel across all frames.
+ * @property cellAlpha Concatenated per-cell alpha across all frames; `NaN` encodes a null alpha.
+ * @property ambient Per-frame ambient parameters, length [frameCount].
+ * @property glyphs Per-frame glyph state, length [frameCount]; an entry is null when no glyph is active.
+ */
+@Serializable
+class VoxelTrace(
+    val formatVersion: Int,
+    val fps: Int,
+    val frameCount: Int,
+    val phosphorVersion: String,
+    val seed: Long,
+    val paramSnapshot: Map<String, String>,
+    val staticLattice: StaticLattice,
+    val segments: List<TraceSegment>,
+    val createdAtEpochMs: Long,
+    val ticks: LongArray,
+    val timestampsEpochMillis: LongArray,
+    val cellCounts: IntArray,
+    val cellX: FloatArray,
+    val cellY: FloatArray,
+    val cellZ: FloatArray,
+    val cellScale: FloatArray,
+    val cellRed: FloatArray,
+    val cellGreen: FloatArray,
+    val cellBlue: FloatArray,
+    val cellAlpha: FloatArray,
+    val ambient: List<VoxelAmbient>,
+    val glyphs: List<VoxelGlyphState?>,
+) {
+    /**
+     * Project this columnar trace back into the `VoxelFrame` sequence it was
+     * recorded from. The result is structurally identical to the input of
+     * [fromFrames] (a `NaN` alpha channel decodes back to a null alpha).
+     */
+    fun toFrames(): List<VoxelFrame> {
+        val frames = ArrayList<VoxelFrame>(frameCount)
+        var cursor = 0
+        for (frameIndex in 0 until frameCount) {
+            val count = cellCounts[frameIndex]
+            val cells = ArrayList<VoxelCell>(count)
+            for (i in 0 until count) {
+                val cellIndex = cursor + i
+                val alpha = cellAlpha[cellIndex]
+                cells +=
+                    VoxelCell(
+                        x = cellX[cellIndex],
+                        y = cellY[cellIndex],
+                        z = cellZ[cellIndex],
+                        scale = cellScale[cellIndex],
+                        red = cellRed[cellIndex],
+                        green = cellGreen[cellIndex],
+                        blue = cellBlue[cellIndex],
+                        alpha = if (alpha.isNaN()) null else alpha,
+                    )
+            }
+            cursor += count
+            frames +=
+                VoxelFrame(
+                    tick = ticks[frameIndex],
+                    timestampEpochMillis = timestampsEpochMillis[frameIndex],
+                    resolution = staticLattice.resolution,
+                    cells = cells,
+                    ambient = ambient[frameIndex],
+                    glyph = glyphs[frameIndex],
+                )
+        }
+        return frames
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VoxelTrace) return false
+        return formatVersion == other.formatVersion &&
+            fps == other.fps &&
+            frameCount == other.frameCount &&
+            phosphorVersion == other.phosphorVersion &&
+            seed == other.seed &&
+            paramSnapshot == other.paramSnapshot &&
+            staticLattice == other.staticLattice &&
+            segments == other.segments &&
+            createdAtEpochMs == other.createdAtEpochMs &&
+            ticks.contentEquals(other.ticks) &&
+            timestampsEpochMillis.contentEquals(other.timestampsEpochMillis) &&
+            cellCounts.contentEquals(other.cellCounts) &&
+            cellX.contentEquals(other.cellX) &&
+            cellY.contentEquals(other.cellY) &&
+            cellZ.contentEquals(other.cellZ) &&
+            cellScale.contentEquals(other.cellScale) &&
+            cellRed.contentEquals(other.cellRed) &&
+            cellGreen.contentEquals(other.cellGreen) &&
+            cellBlue.contentEquals(other.cellBlue) &&
+            cellAlpha.contentEquals(other.cellAlpha) &&
+            ambient == other.ambient &&
+            glyphs == other.glyphs
+    }
+
+    override fun hashCode(): Int {
+        var result = formatVersion
+        result = 31 * result + fps
+        result = 31 * result + frameCount
+        result = 31 * result + phosphorVersion.hashCode()
+        result = 31 * result + seed.hashCode()
+        result = 31 * result + paramSnapshot.hashCode()
+        result = 31 * result + staticLattice.hashCode()
+        result = 31 * result + segments.hashCode()
+        result = 31 * result + createdAtEpochMs.hashCode()
+        result = 31 * result + ticks.contentHashCode()
+        result = 31 * result + timestampsEpochMillis.contentHashCode()
+        result = 31 * result + cellCounts.contentHashCode()
+        result = 31 * result + cellX.contentHashCode()
+        result = 31 * result + cellY.contentHashCode()
+        result = 31 * result + cellZ.contentHashCode()
+        result = 31 * result + cellScale.contentHashCode()
+        result = 31 * result + cellRed.contentHashCode()
+        result = 31 * result + cellGreen.contentHashCode()
+        result = 31 * result + cellBlue.contentHashCode()
+        result = 31 * result + cellAlpha.contentHashCode()
+        result = 31 * result + ambient.hashCode()
+        result = 31 * result + glyphs.hashCode()
+        return result
+    }
+
+    companion object {
+        /** Current trace [formatVersion] written by [fromFrames]. */
+        const val CURRENT_FORMAT_VERSION: Int = 1
+
+        /**
+         * Record [frames] into a columnar [VoxelTrace].
+         *
+         * @param frames Captured frames in playback order; must be non-empty and share one `VoxelFrame.resolution`.
+         * @param fps Frames per second the capture ran at; must be `> 0`.
+         * @param phosphorVersion Phosphor library version that produced the frames.
+         * @param createdAtEpochMs Wall-clock creation time, epoch milliseconds.
+         * @param seed Deterministic producer seed; defaults to `0`.
+         * @param paramSnapshot Serialized tuning parameters active during capture.
+         * @param segments Named slices of the stream; each must fall within `0 until frames.size`.
+         * @throws IllegalArgumentException if the inputs violate the constraints above.
+         */
+        fun fromFrames(
+            frames: List<VoxelFrame>,
+            fps: Int,
+            phosphorVersion: String,
+            createdAtEpochMs: Long,
+            seed: Long = 0L,
+            paramSnapshot: Map<String, String> = emptyMap(),
+            segments: List<TraceSegment> = emptyList(),
+        ): VoxelTrace {
+            require(frames.isNotEmpty()) { "A VoxelTrace requires at least one frame" }
+            require(fps > 0) { "fps must be > 0, was $fps" }
+
+            val resolution = frames.first().resolution
+            require(frames.all { it.resolution == resolution }) {
+                "VoxelTrace requires a uniform lattice resolution across all frames"
+            }
+
+            val frameCount = frames.size
+            segments.forEach { segment ->
+                require(segment.endFrame < frameCount) {
+                    "Segment '${segment.name}' endFrame ${segment.endFrame} is outside the " +
+                        "trace's $frameCount frames"
+                }
+            }
+
+            val totalCells = frames.sumOf { it.cells.size }
+            val ticks = LongArray(frameCount)
+            val timestamps = LongArray(frameCount)
+            val cellCounts = IntArray(frameCount)
+            val cellX = FloatArray(totalCells)
+            val cellY = FloatArray(totalCells)
+            val cellZ = FloatArray(totalCells)
+            val cellScale = FloatArray(totalCells)
+            val cellRed = FloatArray(totalCells)
+            val cellGreen = FloatArray(totalCells)
+            val cellBlue = FloatArray(totalCells)
+            val cellAlpha = FloatArray(totalCells)
+            val ambient = ArrayList<VoxelAmbient>(frameCount)
+            val glyphs = ArrayList<VoxelGlyphState?>(frameCount)
+
+            var cellIndex = 0
+            frames.forEachIndexed { frameIndex, frame ->
+                ticks[frameIndex] = frame.tick
+                timestamps[frameIndex] = frame.timestampEpochMillis
+                cellCounts[frameIndex] = frame.cells.size
+                ambient += frame.ambient
+                glyphs += frame.glyph
+                for (cell in frame.cells) {
+                    cellX[cellIndex] = cell.x
+                    cellY[cellIndex] = cell.y
+                    cellZ[cellIndex] = cell.z
+                    cellScale[cellIndex] = cell.scale
+                    cellRed[cellIndex] = cell.red
+                    cellGreen[cellIndex] = cell.green
+                    cellBlue[cellIndex] = cell.blue
+                    cellAlpha[cellIndex] = cell.alpha ?: Float.NaN
+                    cellIndex++
+                }
+            }
+
+            return VoxelTrace(
+                formatVersion = CURRENT_FORMAT_VERSION,
+                fps = fps,
+                frameCount = frameCount,
+                phosphorVersion = phosphorVersion,
+                seed = seed,
+                paramSnapshot = paramSnapshot,
+                staticLattice = StaticLattice(resolution),
+                segments = segments,
+                createdAtEpochMs = createdAtEpochMs,
+                ticks = ticks,
+                timestampsEpochMillis = timestamps,
+                cellCounts = cellCounts,
+                cellX = cellX,
+                cellY = cellY,
+                cellZ = cellZ,
+                cellScale = cellScale,
+                cellRed = cellRed,
+                cellGreen = cellGreen,
+                cellBlue = cellBlue,
+                cellAlpha = cellAlpha,
+                ambient = ambient,
+                glyphs = glyphs,
+            )
+        }
+    }
+}

--- a/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceCodecRoundTripTest.kt
+++ b/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceCodecRoundTripTest.kt
@@ -1,0 +1,77 @@
+package link.socket.phosphor.trace
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TraceCodecRoundTripTest {
+    @Test
+    fun `random traces encode then decode identically`() {
+        val random = Random(0xC0FFEE)
+        repeat(50) { iteration ->
+            val frames = TraceTestData.randomFrames(random)
+            val trace =
+                VoxelTrace.fromFrames(
+                    frames = frames,
+                    fps = random.nextInt(1, 121),
+                    phosphorVersion = "0.7.0",
+                    createdAtEpochMs = random.nextLong(0, 2_000_000_000_000),
+                    seed = random.nextLong(),
+                    paramSnapshot = mapOf("noise" to random.nextFloat().toString()),
+                    segments = TraceTestData.randomSegments(frames.size, random),
+                )
+
+            val encoded = TraceCodec.encode(trace)
+            val decoded = TraceCodec.decode(encoded).getOrThrow()
+
+            assertEquals(trace, decoded, "VoxelTrace mismatch on iteration $iteration")
+            assertEquals(frames, decoded.toFrames(), "Frame projection mismatch on iteration $iteration")
+        }
+    }
+
+    @Test
+    fun `degenerate frames with empty cells round-trip`() {
+        val frames = TraceTestData.randomFrames(Random(1)).map { it.copy(cells = emptyList()) }
+        val trace =
+            VoxelTrace.fromFrames(
+                frames = frames,
+                fps = 30,
+                phosphorVersion = "0.7.0",
+                createdAtEpochMs = 0L,
+            )
+
+        val decoded = TraceCodec.decode(TraceCodec.encode(trace)).getOrThrow()
+
+        assertEquals(frames, decoded.toFrames())
+        assertTrue(decoded.toFrames().all { it.cells.isEmpty() })
+    }
+
+    @Test
+    fun `null alpha survives the NaN channel encoding`() {
+        val random = Random(7)
+        val frames = TraceTestData.randomFrames(random)
+        val decoded =
+            TraceCodec
+                .decode(
+                    TraceCodec.encode(
+                        VoxelTrace.fromFrames(frames, fps = 24, phosphorVersion = "0.7.0", createdAtEpochMs = 0L),
+                    ),
+                ).getOrThrow()
+
+        val originalNullAlphas = frames.flatMap { it.cells }.count { it.alpha == null }
+        val decodedNullAlphas = decoded.toFrames().flatMap { it.cells }.count { it.alpha == null }
+        assertEquals(originalNullAlphas, decodedNullAlphas)
+    }
+
+    @Test
+    fun `single minimal trace round-trips`() {
+        val trace = TraceTestData.sampleTrace(formatVersion = VoxelTrace.CURRENT_FORMAT_VERSION)
+
+        val decoded = TraceCodec.decode(TraceCodec.encode(trace)).getOrThrow()
+
+        assertEquals(trace, decoded)
+        assertNull(decoded.toFrames().single().glyph)
+    }
+}

--- a/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceFormatVersionTest.kt
+++ b/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceFormatVersionTest.kt
@@ -1,0 +1,46 @@
+package link.socket.phosphor.trace
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class TraceFormatVersionTest {
+    @Test
+    fun `decode rejects an unknown formatVersion`() {
+        val future = TraceTestData.sampleTrace(formatVersion = 999)
+
+        val result = TraceCodec.decode(TraceCodec.encode(future))
+
+        assertTrue(result.isFailure)
+        val error = assertIs<TraceDecodeError.UnsupportedFormatVersion>(result.exceptionOrNull())
+        assertEquals(999, error.foundVersion)
+        assertEquals(TraceCodec.SUPPORTED_FORMAT_VERSION, error.supportedVersion)
+    }
+
+    @Test
+    fun `decode accepts the supported formatVersion`() {
+        val current = TraceTestData.sampleTrace(formatVersion = TraceCodec.SUPPORTED_FORMAT_VERSION)
+
+        val result = TraceCodec.decode(TraceCodec.encode(current))
+
+        assertTrue(result.isSuccess)
+        assertEquals(current, result.getOrThrow())
+    }
+
+    @Test
+    fun `decode reports corrupt bytes as a typed failure`() {
+        val result = TraceCodec.decode(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+
+        assertTrue(result.isFailure)
+        assertIs<TraceDecodeError.Corrupt>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `decode reports empty input as a typed failure`() {
+        val result = TraceCodec.decode(ByteArray(0))
+
+        assertTrue(result.isFailure)
+        assertIs<TraceDecodeError.Corrupt>(result.exceptionOrNull())
+    }
+}

--- a/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceSizeBudgetTest.kt
+++ b/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceSizeBudgetTest.kt
@@ -1,0 +1,131 @@
+package link.socket.phosphor.trace
+
+import kotlin.math.PI
+import kotlin.math.acos
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelCell
+import link.socket.phosphor.lumos.VoxelFrame
+
+class TraceSizeBudgetTest {
+    @Test
+    fun `five second clip encodes within the v1 size ceiling`() {
+        val fps = 30
+        val seconds = 5
+        val frameCount = fps * seconds
+        val voxelCount = 1_500
+
+        val frames = synthesizeFrames(frameCount, voxelCount)
+        val trace =
+            VoxelTrace.fromFrames(
+                frames = frames,
+                fps = fps,
+                phosphorVersion = "0.7.0",
+                createdAtEpochMs = 0L,
+                seed = 42L,
+                paramSnapshot = mapOf("pulseFrequency" to "0.5", "noise" to "0.2"),
+            )
+
+        val encoded = TraceCodec.encode(trace)
+        val sizeBytes = encoded.size
+        val sizeMb = sizeBytes.toDouble() / (1024.0 * 1024.0)
+        val rawFloatChannelBytes = frameCount.toLong() * voxelCount * CELL_FLOAT_CHANNELS * Float.SIZE_BYTES
+
+        println(
+            "[PHO-35] VoxelTrace v1 encoded size: $sizeBytes bytes " +
+                "(${formatMb(sizeMb)} MB) for ${seconds}s @ ${fps}fps × $voxelCount voxels " +
+                "(raw cell-channel floats = $rawFloatChannelBytes bytes; v2 quantization target ≤ 2 MB)",
+        )
+
+        // Round-trips at this scale.
+        val decoded = TraceCodec.decode(encoded).getOrThrow()
+        assertEquals(frameCount, decoded.frameCount)
+        assertEquals(frames, decoded.toFrames())
+
+        // Columnar CBOR + gzip must beat the raw per-frame float footprint.
+        assertTrue(
+            sizeBytes < rawFloatChannelBytes,
+            "Encoded size $sizeBytes should be smaller than raw float channels $rawFloatChannelBytes",
+        )
+
+        // v1 documented ceiling for full-precision traces. ≤ 2 MB is the v2
+        // (quantization) target tracked on PHO-35; v1 reports the real number.
+        assertTrue(
+            sizeBytes <= V1_SIZE_CEILING_BYTES,
+            "Encoded size $sizeBytes exceeded the v1 ceiling $V1_SIZE_CEILING_BYTES",
+        )
+    }
+
+    private fun synthesizeFrames(
+        frameCount: Int,
+        voxelCount: Int,
+    ): List<VoxelFrame> {
+        val twoPi = (2.0 * PI).toFloat()
+        val directions =
+            Array(voxelCount) { index ->
+                val k = index + 0.5
+                val polar = acos(1.0 - 2.0 * k / voxelCount)
+                val azimuth = PI * (1.0 + sqrt(5.0)) * k
+                Triple(
+                    (sin(polar) * cos(azimuth)).toFloat(),
+                    cos(polar).toFloat(),
+                    (sin(polar) * sin(azimuth)).toFloat(),
+                )
+            }
+        // Stable per-voxel radial offset, mirroring the construction-time jitter
+        // of a real lattice (constant across frames, so it compresses well).
+        val jitter = FloatArray(voxelCount) { ((it * 2654435761u.toInt()) and 0xFF) / 255f - 0.5f }
+
+        return List(frameCount) { frameIndex ->
+            val t = frameIndex.toFloat() / 30f
+            val pulse = 1f + 0.05f * sin(t * twoPi * 0.5f)
+            val rotation = t * 0.3f
+            val cosR = cos(rotation)
+            val sinR = sin(rotation)
+            val cells = ArrayList<VoxelCell>(voxelCount)
+            for (index in 0 until voxelCount) {
+                val (dx, dy, dz) = directions[index]
+                val rotatedX = dx * cosR + dz * sinR
+                val rotatedZ = -dx * sinR + dz * cosR
+                val radius = (1.2f + 0.02f * jitter[index]) * pulse
+                val hue = (index.toFloat() / voxelCount + t * 0.1f) % 1f
+                cells +=
+                    VoxelCell(
+                        x = rotatedX * radius,
+                        y = dy * radius,
+                        z = rotatedZ * radius,
+                        scale = 0.9f * pulse,
+                        red = 0.5f + 0.5f * sin(hue * twoPi),
+                        green = 0.5f + 0.5f * sin(hue * twoPi + 2f),
+                        blue = 0.5f + 0.5f * sin(hue * twoPi + 4f),
+                    )
+            }
+            VoxelFrame(
+                tick = frameIndex.toLong(),
+                timestampEpochMillis = (t * 1000f).toLong(),
+                resolution = 7,
+                cells = cells,
+                ambient = VoxelAmbient(0.3f, 0.4f, 0.5f, 0.8f, rotation, 0f, 0f),
+            )
+        }
+    }
+
+    private fun formatMb(value: Double): String {
+        val hundredths = (value * 100.0 + 0.5).toLong()
+        return "${hundredths / 100}.${(hundredths % 100).toString().padStart(2, '0')}"
+    }
+
+    private companion object {
+        const val CELL_FLOAT_CHANNELS = 7
+
+        // Measured ~2.70 MB on JVM for this synthetic clip. The ceiling guards
+        // against regressions with headroom for cross-platform gzip variance;
+        // ≤ 2 MB remains the v2 (quantization) target, not a v1 gate.
+        const val V1_SIZE_CEILING_BYTES = 4 * 1024 * 1024
+    }
+}

--- a/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceTestData.kt
+++ b/phosphor-trace/src/commonTest/kotlin/link/socket/phosphor/trace/TraceTestData.kt
@@ -1,0 +1,106 @@
+package link.socket.phosphor.trace
+
+import kotlin.random.Random
+import link.socket.phosphor.lumos.VoxelAmbient
+import link.socket.phosphor.lumos.VoxelCell
+import link.socket.phosphor.lumos.VoxelFrame
+import link.socket.phosphor.lumos.VoxelGlyphState
+
+/** Shared fixtures for the trace codec tests. */
+internal object TraceTestData {
+    private val glyphNames = listOf("SPARK", "PULSE", "BLOOM", "WAVE")
+    private val segmentNames = listOf("idle", "thinking", "idle→thinking", "thinking→idle")
+
+    /** A random, internally consistent frame stream with a uniform resolution. */
+    fun randomFrames(random: Random): List<VoxelFrame> {
+        val resolution = random.nextInt(0, 11)
+        val frameCount = random.nextInt(1, 7)
+        return List(frameCount) { frameIndex ->
+            val cellCount = random.nextInt(0, 9)
+            val cells =
+                List(cellCount) {
+                    VoxelCell(
+                        x = random.nextFloat() * 4f - 2f,
+                        y = random.nextFloat() * 4f - 2f,
+                        z = random.nextFloat() * 4f - 2f,
+                        scale = random.nextFloat(),
+                        red = random.nextFloat(),
+                        green = random.nextFloat(),
+                        blue = random.nextFloat(),
+                        alpha = if (random.nextBoolean()) random.nextFloat() else null,
+                    )
+                }
+            VoxelFrame(
+                tick = frameIndex.toLong(),
+                timestampEpochMillis = random.nextLong(0, 1_000_000),
+                resolution = resolution,
+                cells = cells,
+                ambient =
+                    VoxelAmbient(
+                        glowRed = random.nextFloat(),
+                        glowGreen = random.nextFloat(),
+                        glowBlue = random.nextFloat(),
+                        glowIntensity = random.nextFloat(),
+                        orbRotationX = random.nextFloat(),
+                        orbRotationY = random.nextFloat(),
+                        orbRotationZ = random.nextFloat(),
+                    ),
+                glyph =
+                    if (random.nextBoolean()) {
+                        VoxelGlyphState(
+                            glyphName = glyphNames.random(random),
+                            progress = random.nextFloat(),
+                            red = random.nextFloat(),
+                            green = random.nextFloat(),
+                            blue = random.nextFloat(),
+                        )
+                    } else {
+                        null
+                    },
+            )
+        }
+    }
+
+    /** Up to two valid segments inside `0 until frameCount`. */
+    fun randomSegments(
+        frameCount: Int,
+        random: Random,
+    ): List<TraceSegment> =
+        List(random.nextInt(0, 3)) {
+            val start = random.nextInt(0, frameCount)
+            val end = random.nextInt(start, frameCount)
+            TraceSegment(
+                name = segmentNames.random(random),
+                startFrame = start,
+                endFrame = end,
+                loop = random.nextBoolean(),
+            )
+        }
+
+    /** A minimal single-frame trace built directly, with a controllable [formatVersion]. */
+    fun sampleTrace(formatVersion: Int): VoxelTrace =
+        VoxelTrace(
+            formatVersion = formatVersion,
+            fps = 30,
+            frameCount = 1,
+            phosphorVersion = "0.7.0",
+            seed = 1L,
+            paramSnapshot = mapOf("pulseFrequency" to "0.5"),
+            staticLattice = StaticLattice(4),
+            segments = emptyList(),
+            createdAtEpochMs = 0L,
+            ticks = longArrayOf(0L),
+            timestampsEpochMillis = longArrayOf(0L),
+            cellCounts = intArrayOf(1),
+            cellX = floatArrayOf(0.1f),
+            cellY = floatArrayOf(0.2f),
+            cellZ = floatArrayOf(0.3f),
+            cellScale = floatArrayOf(0.9f),
+            cellRed = floatArrayOf(0.4f),
+            cellGreen = floatArrayOf(0.5f),
+            cellBlue = floatArrayOf(0.6f),
+            cellAlpha = floatArrayOf(Float.NaN),
+            ambient = listOf(VoxelAmbient(0f, 0f, 0f, 0f, 0f, 0f, 0f)),
+            glyphs = listOf(null),
+        )
+}

--- a/phosphor-trace/src/iosMain/kotlin/link/socket/phosphor/trace/Gzip.ios.kt
+++ b/phosphor-trace/src/iosMain/kotlin/link/socket/phosphor/trace/Gzip.ios.kt
@@ -1,0 +1,119 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package link.socket.phosphor.trace
+
+import kotlinx.cinterop.*
+import platform.posix.memset
+import platform.zlib.*
+
+// Apple targets carry no JVM gzip; the bundled `platform.zlib` interop drives
+// standard gzip (RFC 1952) framing so a trace encoded here decodes on the JVM
+// and vice versa. windowBits of MAX_WBITS + 16 selects gzip on deflate; + 32
+// auto-detects the gzip wrapper on inflate.
+
+private const val ZLIB_CHUNK = 32 * 1024
+private const val DEFLATE_GZIP_WINDOW_BITS = MAX_WBITS + 16
+private const val INFLATE_GZIP_WINDOW_BITS = MAX_WBITS + 32
+private const val DEFAULT_MEM_LEVEL = 8
+
+internal actual fun gzipCompress(data: ByteArray): ByteArray =
+    memScoped {
+        val stream = alloc<z_stream>()
+        memset(stream.ptr, 0, sizeOf<z_stream>().convert())
+        val initCode =
+            deflateInit2_(
+                stream.ptr,
+                Z_DEFAULT_COMPRESSION,
+                Z_DEFLATED,
+                DEFLATE_GZIP_WINDOW_BITS,
+                DEFAULT_MEM_LEVEL,
+                Z_DEFAULT_STRATEGY,
+                ZLIB_VERSION,
+                sizeOf<z_stream>().convert(),
+            )
+        check(initCode == Z_OK) { "zlib deflateInit2 failed: $initCode" }
+        try {
+            drive(stream, data, Z_FINISH) { deflate(stream.ptr, it) }
+        } finally {
+            deflateEnd(stream.ptr)
+        }
+    }
+
+internal actual fun gzipDecompress(data: ByteArray): ByteArray =
+    memScoped {
+        val stream = alloc<z_stream>()
+        memset(stream.ptr, 0, sizeOf<z_stream>().convert())
+        val initCode =
+            inflateInit2_(
+                stream.ptr,
+                INFLATE_GZIP_WINDOW_BITS,
+                ZLIB_VERSION,
+                sizeOf<z_stream>().convert(),
+            )
+        check(initCode == Z_OK) { "zlib inflateInit2 failed: $initCode" }
+        try {
+            drive(stream, data, Z_NO_FLUSH) { inflate(stream.ptr, it) }
+        } finally {
+            inflateEnd(stream.ptr)
+        }
+    }
+
+/**
+ * Feed [input] through an initialized zlib [stream] and collect the output.
+ *
+ * [flush] is `Z_FINISH` for deflate (all input is available up front) and
+ * `Z_NO_FLUSH` for inflate; [step] invokes `deflate`/`inflate` with the flush.
+ * The loop drains the output buffer each pass and stops at `Z_STREAM_END`, or at
+ * `Z_BUF_ERROR` once no further progress is possible.
+ */
+private fun MemScope.drive(
+    stream: z_stream,
+    input: ByteArray,
+    flush: Int,
+    step: (Int) -> Int,
+): ByteArray {
+    val outBuffer = allocArray<ByteVar>(ZLIB_CHUNK)
+    val chunks = mutableListOf<ByteArray>()
+
+    fun pump(): ByteArray {
+        while (true) {
+            stream.next_out = outBuffer.reinterpret()
+            stream.avail_out = ZLIB_CHUNK.convert()
+            val code = step(flush)
+            val produced = ZLIB_CHUNK - stream.avail_out.toInt()
+            if (produced > 0) chunks += outBuffer.readBytes(produced)
+            when (code) {
+                Z_STREAM_END -> break
+                Z_OK -> continue
+                Z_BUF_ERROR -> break
+                else -> error("zlib step failed: $code")
+            }
+        }
+        return concatenate(chunks)
+    }
+
+    if (input.isEmpty()) {
+        stream.next_in = null
+        stream.avail_in = 0u
+        return pump()
+    }
+    return input.usePinned { pinned ->
+        stream.next_in = pinned.addressOf(0).reinterpret()
+        stream.avail_in = input.size.convert()
+        pump()
+    }
+}
+
+private fun concatenate(chunks: List<ByteArray>): ByteArray {
+    if (chunks.isEmpty()) return ByteArray(0)
+    if (chunks.size == 1) return chunks[0]
+    val total = chunks.sumOf { it.size }
+    val result = ByteArray(total)
+    var offset = 0
+    for (chunk in chunks) {
+        chunk.copyInto(result, offset)
+        offset += chunk.size
+    }
+    return result
+}

--- a/phosphor-trace/src/jvmMain/kotlin/link/socket/phosphor/trace/Gzip.jvm.kt
+++ b/phosphor-trace/src/jvmMain/kotlin/link/socket/phosphor/trace/Gzip.jvm.kt
@@ -1,0 +1,15 @@
+package link.socket.phosphor.trace
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+internal actual fun gzipCompress(data: ByteArray): ByteArray {
+    val sink = ByteArrayOutputStream()
+    GZIPOutputStream(sink).use { it.write(data) }
+    return sink.toByteArray()
+}
+
+internal actual fun gzipDecompress(data: ByteArray): ByteArray =
+    GZIPInputStream(ByteArrayInputStream(data)).use { it.readBytes() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(":phosphor-core")
 include(":phosphor-lumos")
 include(":phosphor-lumos-cli")
 include(":phosphor-lumos-compose")
+include(":phosphor-trace")
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
## Summary

Introduces `phosphor-trace`, a new Kotlin Multiplatform module that defines a versioned, columnar binary format for recording and replaying sequences of `VoxelFrame` data. The format uses CBOR serialization with gzip compression and includes metadata for segments, parameters, and frame timing.

## Key Changes

- **VoxelTrace data model**: A columnar format that stores per-frame voxel cell attributes (position, scale, color, alpha) in separate primitive arrays for optimal compression. Includes metadata such as FPS, resolution, seed, and parameter snapshots.

- **StaticLattice**: Minimal lattice descriptor carrying only the resolution, which is constant across all frames in a trace.

- **TraceSegment**: Named, replayable slices of the frame stream (e.g., "idle", "thinking", "idle→thinking") with loop control.

- **TraceCodec**: Round-trip serialization using CBOR + gzip with typed error handling:
  - `encode()`: Converts a `VoxelTrace` to a compressed `.vxt` payload
  - `decode()`: Inflates and parses with version validation, returning `Result<VoxelTrace>`
  - Typed `TraceDecodeError` hierarchy for `Corrupt` and `UnsupportedFormatVersion` failures

- **Platform-specific gzip implementations**:
  - JVM: Uses `java.util.zip.GZIPInputStream/OutputStream`
  - iOS: Uses bundled `platform.zlib` interop for RFC 1952 standard gzip framing, ensuring cross-platform compatibility

- **Conversion methods**:
  - `VoxelTrace.fromFrames()`: Records a `List<VoxelFrame>` into columnar format with validation
  - `VoxelTrace.toFrames()`: Projects the columnar trace back to the original frame sequence (NaN alpha decodes to null)

- **Comprehensive test suite**:
  - Round-trip encoding/decoding with random frame data
  - Format version validation and rejection of unsupported versions
  - Size budget verification (v1 full-precision ceiling at 4 MB for synthetic 5-second clips)
  - Edge cases: empty cells, null alpha channels, minimal traces

## Notable Implementation Details

- **Columnar storage**: All x-coordinates, then all y-coordinates, etc., grouped by channel for superior gzip compression compared to interleaved struct arrays.
- **NaN encoding**: Null alpha values are encoded as `Float.NaN` in the columnar array and decoded back to null on projection.
- **Version gating**: Format version is checked on decode; v1 is full-precision CBOR + gzip, with quantization reserved for v2.
- **Multiplatform**: Gradle build targets JVM (Java 21) and iOS (x64, arm64, simulator arm64) with proper serialization and signing configuration.

https://claude.ai/code/session_01NaiNGeuazDjtu59X3TkZvY