### PR TITLE
Add FrameProbe instrumentation for per-phase frame timing (PHO-34)

### DIFF
--- a/phosphor-lumos-cli/build.gradle.kts
+++ b/phosphor-lumos-cli/build.gradle.kts
@@ -62,6 +62,19 @@ kotlin {
     }
 }
 
+// PHO-34: run the FrameProbe baseline harness against the CLI Lumos path.
+// Usage: ./gradlew :phosphor-lumos-cli:runFrameProbeBenchmark            (60s default)
+//        ./gradlew :phosphor-lumos-cli:runFrameProbeBenchmark -Pduration=120
+tasks.register<JavaExec>("runFrameProbeBenchmark") {
+    group = "verification"
+    description = "Run the FrameProbe build/project/draw baseline harness (PHO-34, Task C)."
+    val jvmMain = kotlin.targets.getByName("jvm").compilations.getByName("main")
+    dependsOn(jvmMain.compileTaskProvider)
+    classpath = files(jvmMain.output.allOutputs, jvmMain.runtimeDependencyFiles)
+    mainClass.set("link.socket.phosphor.lumos.cli.bench.FrameProbeBenchmarkKt")
+    (project.findProperty("duration") as String?)?.let { args(it) }
+}
+
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()

--- a/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/projection/CliLattice.kt
+++ b/phosphor-lumos-cli/src/commonMain/kotlin/link/socket/phosphor/lumos/cli/projection/CliLattice.kt
@@ -6,6 +6,9 @@ import link.socket.phosphor.color.OklabColor
 import link.socket.phosphor.lumos.VoxelFrame
 import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
 import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
+import link.socket.phosphor.lumos.probe.FramePhase
+import link.socket.phosphor.lumos.probe.FrameProbe
+import link.socket.phosphor.lumos.probe.measure
 
 /**
  * Orthographic projection of a VoxelFrame to a [LumosTerminalFrame].
@@ -31,11 +34,15 @@ import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame.TerminalCell
  * @param characterAspectRatio Ratio of character cell height to width.
  *  Defaults to 2.0 because most monospace fonts render characters at ~1:2
  *  width:height. Configurable for high-DPI terminals or custom fonts.
+ * @param probe Per-phase timing sink. Defaults to [FrameProbe.Disabled], which
+ *  adds no per-frame cost; pass a [link.socket.phosphor.lumos.probe.RingBufferFrameProbe]
+ *  to capture PROJECT timings.
  */
 class CliLattice(
     val width: Int,
     val height: Int,
     val characterAspectRatio: Float = 2.0f,
+    private val probe: FrameProbe = FrameProbe.Disabled,
 ) {
     init {
         require(width > 0) { "width must be > 0, got $width" }
@@ -60,7 +67,9 @@ class CliLattice(
      *
      * Ambient and glyph state pass through unchanged.
      */
-    fun project(frame: VoxelFrame): LumosTerminalFrame {
+    fun project(frame: VoxelFrame): LumosTerminalFrame = probe.measure(FramePhase.PROJECT) { projectFrame(frame) }
+
+    private fun projectFrame(frame: VoxelFrame): LumosTerminalFrame {
         val winningIndex = IntArray(cellCount) { -1 }
         val winningZ = FloatArray(cellCount)
         val cells = frame.cells

--- a/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/bench/FrameProbeBenchmark.kt
+++ b/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/bench/FrameProbeBenchmark.kt
@@ -1,0 +1,206 @@
+package link.socket.phosphor.lumos.cli.bench
+
+import java.io.OutputStream
+import java.io.PrintStream
+import link.socket.phosphor.lumos.VoxelFrameBuilder
+import link.socket.phosphor.lumos.cli.glyph.CliGlyph
+import link.socket.phosphor.lumos.cli.projection.CliLattice
+import link.socket.phosphor.lumos.cli.renderer.CliOrb
+import link.socket.phosphor.lumos.cli.renderer.TerminalSize
+import link.socket.phosphor.lumos.probe.FramePhase
+import link.socket.phosphor.lumos.probe.FrameProbe
+import link.socket.phosphor.lumos.probe.FrameProbeSummary
+import link.socket.phosphor.lumos.probe.PhaseStats
+import link.socket.phosphor.lumos.probe.RingBufferFrameProbe
+import link.socket.phosphor.palette.AtmospherePresets
+import link.socket.phosphor.runtime.CognitiveSceneRuntime
+import link.socket.phosphor.runtime.SceneConfiguration
+
+/**
+ * JVM baseline harness for [FrameProbe] (PHO-34, Task C).
+ *
+ * Drives the full CLI Lumos frame loop — `CognitiveSceneRuntime.update` →
+ * `VoxelFrameBuilder.build` (BUILD) → `CliLattice.project` (PROJECT) →
+ * `CliOrb.render` (DRAW) — for a fixed wall-clock duration with the probe
+ * enabled, then prints a p50/p95/max table per phase. Terminal output is sunk
+ * into a discarding stream so DRAW measures ANSI assembly and write cost
+ * without flooding a real terminal.
+ *
+ * This is the CLI projection/draw path: it is the only fully JVM-drawable
+ * surface in the repo today. The Compose path (`ComposeLattice` + `LumosCanvas`,
+ * ~1,500-voxel `drawRect`) needs a Compose host and is out of scope here; the
+ * gap is noted in the run output.
+ *
+ * Run: `./gradlew :phosphor-lumos-cli:runFrameProbeBenchmark` (60s) or pass a
+ * duration in seconds as the first argument.
+ */
+private const val DEFAULT_DURATION_SECONDS = 60
+private const val WARMUP_SECONDS = 3
+private const val FIXED_DT_SECONDS = 1f / 60f
+private const val GRID_WIDTH = 64
+private const val GRID_HEIGHT = 32
+private const val OVERHEAD_FRAMES = 3_000
+private const val OVERHEAD_ROUNDS = 3
+
+fun main(args: Array<String>) {
+    val durationSeconds = args.getOrNull(0)?.toIntOrNull()?.coerceAtLeast(1) ?: DEFAULT_DURATION_SECONDS
+
+    val enabledProbe = RingBufferFrameProbe()
+    val enabled = newPipeline(enabledProbe)
+    val voxelCount = enabled.frameVoxelCount()
+
+    println("FrameProbe baseline - CLI path (BUILD + PROJECT + DRAW)")
+    println("grid=${GRID_WIDTH}x$GRID_HEIGHT  voxels/frame=$voxelCount  tickDt=${FIXED_DT_SECONDS}s")
+    println("warmup=${WARMUP_SECONDS}s  measured=${durationSeconds}s")
+    println()
+
+    // Warm the JIT, then discard warm-up samples before the measured window.
+    runFor(enabled, WARMUP_SECONDS)
+    enabledProbe.reset()
+    val measuredFrames = runFor(enabled, durationSeconds)
+
+    printSummary(enabledProbe.summary(), measuredFrames, durationSeconds)
+
+    println()
+    printOverheadComparison()
+}
+
+/** One pipeline instance: a runtime plus the three measured stages, all sharing [probe]. */
+private class Pipeline(
+    private val runtime: CognitiveSceneRuntime,
+    private val builder: VoxelFrameBuilder,
+    private val lattice: CliLattice,
+    private val orb: CliOrb,
+) {
+    fun step() {
+        val snapshot = runtime.update(FIXED_DT_SECONDS)
+        val frame = builder.build(snapshot, FIXED_DT_SECONDS)
+        val projected = lattice.project(frame)
+        orb.render(CliGlyph.overlay(projected))
+    }
+
+    fun frameVoxelCount(): Int {
+        val snapshot = runtime.update(FIXED_DT_SECONDS)
+        return builder.build(snapshot, FIXED_DT_SECONDS).cells.size
+    }
+}
+
+private fun newPipeline(probe: FrameProbe): Pipeline {
+    val config =
+        SceneConfiguration(
+            width = GRID_WIDTH,
+            height = GRID_HEIGHT,
+            enableAtmosphere = true,
+            initialAtmosphere = AtmospherePresets.THINKING,
+        )
+    val runtime = CognitiveSceneRuntime(config)
+    val builder = VoxelFrameBuilder(initialResolution = config.initialAtmosphere.resolution, probe = probe)
+    val lattice = CliLattice(width = GRID_WIDTH, height = GRID_HEIGHT, probe = probe)
+    val orb =
+        CliOrb(
+            out = discardingStream(),
+            terminalSize = TerminalSize.fixed(GRID_WIDTH, GRID_HEIGHT + 2),
+            lattice = lattice,
+            probe = probe,
+        )
+    return Pipeline(runtime, builder, lattice, orb)
+}
+
+/** Drive [pipeline] until [seconds] of wall-clock elapse; returns the frame count. */
+private fun runFor(
+    pipeline: Pipeline,
+    seconds: Int,
+): Long {
+    val deadline = System.nanoTime() + seconds * 1_000_000_000L
+    var frames = 0L
+    while (System.nanoTime() < deadline) {
+        pipeline.step()
+        frames++
+    }
+    return frames
+}
+
+/**
+ * Zero-overhead-when-off check: time a fixed frame count with the probe enabled
+ * vs disabled and report the per-frame delta. Reports the min across rounds to
+ * shed scheduling noise.
+ */
+private fun printOverheadComparison() {
+    val disabled = newPipeline(FrameProbe.Disabled)
+    val enabled = newPipeline(RingBufferFrameProbe())
+
+    // Warm both before timing.
+    repeat(OVERHEAD_FRAMES) { disabled.step() }
+    repeat(OVERHEAD_FRAMES) { enabled.step() }
+
+    val disabledNs = minRoundNanosPerFrame(disabled)
+    val enabledNs = minRoundNanosPerFrame(enabled)
+    val deltaNs = enabledNs - disabledNs
+    val pct = if (disabledNs > 0) deltaNs * 100.0 / disabledNs else 0.0
+
+    println("Zero-overhead-when-off ($OVERHEAD_FRAMES frames/round, min of $OVERHEAD_ROUNDS rounds):")
+    println("  probe OFF : ${formatNanos(disabledNs)}/frame")
+    println("  probe ON  : ${formatNanos(enabledNs)}/frame")
+    println("  delta     : ${formatNanos(deltaNs)}/frame (${formatSigned(pct)}%)")
+}
+
+private fun minRoundNanosPerFrame(pipeline: Pipeline): Long {
+    var best = Long.MAX_VALUE
+    repeat(OVERHEAD_ROUNDS) {
+        val start = System.nanoTime()
+        repeat(OVERHEAD_FRAMES) { pipeline.step() }
+        val perFrame = (System.nanoTime() - start) / OVERHEAD_FRAMES
+        if (perFrame < best) best = perFrame
+    }
+    return best
+}
+
+private fun printSummary(
+    summary: FrameProbeSummary,
+    frames: Long,
+    seconds: Int,
+) {
+    val fps = if (seconds > 0) frames.toDouble() / seconds else 0.0
+    println("Frames measured: $frames  (${"%.0f".format(fps)} fps uncapped)")
+    println()
+    println("Phase    | samples | p50        | p95        | max")
+    println("---------|---------|------------|------------|------------")
+    for (phase in FramePhase.entries) {
+        println(formatRow(summary.forPhase(phase)))
+    }
+}
+
+private fun formatRow(stats: PhaseStats): String =
+    buildString {
+        append(stats.phase.name.padEnd(8))
+        append(" | ")
+        append(stats.sampleCount.toString().padStart(7))
+        append(" | ")
+        append(formatNanos(stats.p50Nanos).padStart(10))
+        append(" | ")
+        append(formatNanos(stats.p95Nanos).padStart(10))
+        append(" | ")
+        append(formatNanos(stats.maxNanos).padStart(10))
+    }
+
+private fun formatNanos(nanos: Long): String =
+    when {
+        nanos >= 1_000_000L -> "%.2f ms".format(nanos / 1_000_000.0)
+        nanos >= 1_000L -> "%.1f us".format(nanos / 1_000.0)
+        else -> "$nanos ns"
+    }
+
+private fun formatSigned(value: Double): String = (if (value >= 0) "+" else "") + "%.1f".format(value)
+
+private fun discardingStream(): PrintStream =
+    PrintStream(
+        object : OutputStream() {
+            override fun write(b: Int) = Unit
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) = Unit
+        },
+    )

--- a/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/CliOrb.kt
+++ b/phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/renderer/CliOrb.kt
@@ -10,6 +10,9 @@ import link.socket.phosphor.lumos.VoxelFrame
 import link.socket.phosphor.lumos.cli.frame.LumosTerminalFrame
 import link.socket.phosphor.lumos.cli.glyph.CliGlyph
 import link.socket.phosphor.lumos.cli.projection.CliLattice
+import link.socket.phosphor.lumos.probe.FramePhase
+import link.socket.phosphor.lumos.probe.FrameProbe
+import link.socket.phosphor.lumos.probe.measure
 
 /**
  * JVM terminal renderer for [LumosTerminalFrame].
@@ -46,6 +49,9 @@ import link.socket.phosphor.lumos.cli.projection.CliLattice
  *  disable polling entirely (useful in tests that drive resize manually).
  * @param lattice Optional projection lattice. Required only when callers use
  *  the [LumosRenderer] interface method `render(VoxelFrame)` directly.
+ * @param probe Per-phase timing sink. Defaults to [FrameProbe.Disabled], which
+ *  adds no per-frame cost; pass a [link.socket.phosphor.lumos.probe.RingBufferFrameProbe]
+ *  to capture DRAW timings (the terminal write).
  */
 class CliOrb(
     private val out: PrintStream = System.out,
@@ -55,6 +61,7 @@ class CliOrb(
     private val terminalSize: TerminalSize = DefaultTerminalSize(),
     private val resizePollFrames: Int = DEFAULT_RESIZE_POLL_FRAMES,
     private val lattice: CliLattice? = null,
+    private val probe: FrameProbe = FrameProbe.Disabled,
 ) : LumosRenderer<LumosTerminalFrame> {
     init {
         require(targetFps > 0) { "targetFps must be > 0, got $targetFps" }
@@ -104,7 +111,10 @@ class CliOrb(
      */
     fun render(frame: LumosTerminalFrame) {
         if (stopped) return
+        probe.measure(FramePhase.DRAW) { renderFrame(frame) }
+    }
 
+    private fun renderFrame(frame: LumosTerminalFrame) {
         var forceFull = clearMode == ClearMode.FULL
         if (!initialized) {
             out.print(CURSOR_HIDE)

--- a/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/LumosCanvas.kt
+++ b/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/LumosCanvas.kt
@@ -22,6 +22,9 @@ import kotlin.math.sin
 import link.socket.phosphor.lumos.VoxelAmbient
 import link.socket.phosphor.lumos.VoxelGlyphState
 import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame
+import link.socket.phosphor.lumos.probe.FramePhase
+import link.socket.phosphor.lumos.probe.FrameProbe
+import link.socket.phosphor.lumos.probe.measure
 
 /**
  * Renders a [LumosCanvasFrame] as a Compose Canvas.
@@ -39,6 +42,8 @@ import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame
  * @param backgroundColor Optional opaque background drawn before halo and voxels. Transparent by default.
  * @param showHalo    Paint the ambient breath-ring gradient behind the orb. Defaults to true.
  * @param showGlyphOverlay Overlay the active glyph when [LumosCanvasFrame.glyph] is non-null. Defaults to true.
+ * @param probe Per-phase timing sink. Defaults to [FrameProbe.Disabled], which adds no per-paint
+ *  cost; pass a [link.socket.phosphor.lumos.probe.RingBufferFrameProbe] to capture DRAW timings.
  */
 @Stable
 @Composable
@@ -48,21 +53,24 @@ fun LumosCanvas(
     backgroundColor: Color = Color.Transparent,
     showHalo: Boolean = true,
     showGlyphOverlay: Boolean = true,
+    probe: FrameProbe = FrameProbe.Disabled,
 ) {
     Canvas(modifier = modifier) {
-        if (backgroundColor != Color.Transparent) {
-            drawRect(backgroundColor)
-        }
-        if (showHalo) drawHalo(frame.ambient)
-        for (voxel in frame.voxels.sortedBy { it.z }) {
-            drawRect(
-                color = Color(voxel.red, voxel.green, voxel.blue, voxel.alpha),
-                topLeft = Offset(voxel.screenX - voxel.radiusPx, voxel.screenY - voxel.radiusPx),
-                size = Size(voxel.radiusPx * 2f, voxel.radiusPx * 2f),
-            )
-        }
-        if (showGlyphOverlay) {
-            frame.glyph?.let { drawGlyph(it) }
+        probe.measure(FramePhase.DRAW) {
+            if (backgroundColor != Color.Transparent) {
+                drawRect(backgroundColor)
+            }
+            if (showHalo) drawHalo(frame.ambient)
+            for (voxel in frame.voxels.sortedBy { it.z }) {
+                drawRect(
+                    color = Color(voxel.red, voxel.green, voxel.blue, voxel.alpha),
+                    topLeft = Offset(voxel.screenX - voxel.radiusPx, voxel.screenY - voxel.radiusPx),
+                    size = Size(voxel.radiusPx * 2f, voxel.radiusPx * 2f),
+                )
+            }
+            if (showGlyphOverlay) {
+                frame.glyph?.let { drawGlyph(it) }
+            }
         }
     }
 }

--- a/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLattice.kt
+++ b/phosphor-lumos-compose/src/commonMain/kotlin/link/socket/phosphor/lumos/compose/projection/ComposeLattice.kt
@@ -5,6 +5,9 @@ import kotlin.math.sin
 import link.socket.phosphor.lumos.VoxelFrame
 import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame
 import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame.CanvasVoxel
+import link.socket.phosphor.lumos.probe.FramePhase
+import link.socket.phosphor.lumos.probe.FrameProbe
+import link.socket.phosphor.lumos.probe.measure
 
 /**
  * Orthographic projection of a [VoxelFrame] to a [LumosCanvasFrame] for Compose Canvas rendering.
@@ -27,12 +30,16 @@ import link.socket.phosphor.lumos.compose.frame.LumosCanvasFrame.CanvasVoxel
  * @param voxelRadiusPx Base voxel half-size in pixels at `scale = 1.0`; must be > 0.
  * @param aspectRatio Pixel aspect ratio applied to the Y axis; defaults to 1.0 for square pixels.
  *  Must be > 0.
+ * @param probe Per-phase timing sink. Defaults to [FrameProbe.Disabled], which
+ *  adds no per-frame cost; pass a [link.socket.phosphor.lumos.probe.RingBufferFrameProbe]
+ *  to capture PROJECT timings.
  */
 class ComposeLattice(
     val widthPx: Int,
     val heightPx: Int,
     val voxelRadiusPx: Float = 4f,
     val aspectRatio: Float = 1.0f,
+    private val probe: FrameProbe = FrameProbe.Disabled,
 ) {
     init {
         require(widthPx > 0) { "widthPx must be > 0, got $widthPx" }
@@ -56,7 +63,9 @@ class ComposeLattice(
      *
      * Ambient and glyph state pass through unchanged.
      */
-    fun project(frame: VoxelFrame): LumosCanvasFrame {
+    fun project(frame: VoxelFrame): LumosCanvasFrame = probe.measure(FramePhase.PROJECT) { projectFrame(frame) }
+
+    private fun projectFrame(frame: VoxelFrame): LumosCanvasFrame {
         val cells = frame.cells
         val ambient = frame.ambient
 

--- a/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/VoxelFrameBuilder.kt
+++ b/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/VoxelFrameBuilder.kt
@@ -7,6 +7,9 @@ import link.socket.phosphor.color.NeutralColor
 import link.socket.phosphor.field.Voxel
 import link.socket.phosphor.field.VoxelSphere
 import link.socket.phosphor.field.facingCamera
+import link.socket.phosphor.lumos.probe.FramePhase
+import link.socket.phosphor.lumos.probe.FrameProbe
+import link.socket.phosphor.lumos.probe.measure
 import link.socket.phosphor.math.Vector3
 import link.socket.phosphor.runtime.SceneSnapshot
 import link.socket.phosphor.signal.AtmospherePattern
@@ -30,10 +33,14 @@ import link.socket.phosphor.signal.AtmosphereTransition
  * @param initialResolution Starting resolution for the underlying
  *  [VoxelSphere]. Rebuilt when [AtmosphereState.resolution] changes.
  * @param config Optional embedder knobs; see [LumosRenderConfig].
+ * @param probe Per-phase timing sink. Defaults to [FrameProbe.Disabled], which
+ *  adds no per-frame cost; pass a [link.socket.phosphor.lumos.probe.RingBufferFrameProbe]
+ *  to capture BUILD timings.
  */
 class VoxelFrameBuilder(
     initialResolution: Int,
     private val config: LumosRenderConfig = LumosRenderConfig(),
+    private val probe: FrameProbe = FrameProbe.Disabled,
 ) {
     /**
      * Continuous breath-pulse phase in radians.
@@ -104,6 +111,11 @@ class VoxelFrameBuilder(
      *  (`SceneConfiguration.enableAtmosphere = false`).
      */
     fun build(
+        snapshot: SceneSnapshot,
+        dt: Float,
+    ): VoxelFrame = probe.measure(FramePhase.BUILD) { buildFrame(snapshot, dt) }
+
+    private fun buildFrame(
         snapshot: SceneSnapshot,
         dt: Float,
     ): VoxelFrame {

--- a/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/FramePhase.kt
+++ b/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/FramePhase.kt
@@ -1,0 +1,21 @@
+package link.socket.phosphor.lumos.probe
+
+/**
+ * The three distinct phases of a Lumos frame, each measured independently by
+ * [FrameProbe].
+ *
+ * A `Probe` inspects without altering: these names identify *where* a
+ * frame-millisecond is spent, not how the work is done.
+ *
+ * - [BUILD] — `VoxelFrameBuilder.build(snapshot)`: turning a runtime snapshot
+ *   into a [link.socket.phosphor.lumos.VoxelFrame] of voxel cells.
+ * - [PROJECT] — projecting that voxel frame to a surface-specific 2D frame
+ *   (`ComposeLattice.project` / `CliLattice.project`).
+ * - [DRAW] — painting the projected voxels to the surface (`LumosCanvas`
+ *   composable / `CliOrb` terminal write).
+ */
+enum class FramePhase {
+    BUILD,
+    PROJECT,
+    DRAW,
+}

--- a/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/FrameProbe.kt
+++ b/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/FrameProbe.kt
@@ -1,0 +1,76 @@
+package link.socket.phosphor.lumos.probe
+
+import kotlin.time.TimeSource
+
+/**
+ * Per-phase frame-timing sink. A `Probe` inspects without altering — measuring
+ * a phase never changes the value the wrapped block produces.
+ *
+ * The probe is **off by default**: callers that do not opt in receive
+ * [Disabled], a no-op singleton. Because [measure] is `inline`, a disabled
+ * probe compiles down to the wrapped block plus a single predictable branch on
+ * [isEnabled] — no [TimeSource] read, no lambda allocation, no per-frame
+ * garbage. See [RingBufferFrameProbe] for the enabled implementation.
+ *
+ * Implementations are single-threaded by contract, matching the Lumos frame
+ * loop (`CognitiveSceneRuntime` and `VoxelFrameBuilder` are themselves
+ * single-threaded, pull-based). [record] and [summary] must not be called
+ * concurrently.
+ */
+interface FrameProbe {
+    /**
+     * Whether this probe records samples. When false, [measure] skips all
+     * timing work. Constant for the probe's lifetime so the branch in [measure]
+     * stays predictable.
+     */
+    val isEnabled: Boolean
+
+    /** Record a single [nanos] duration sample for [phase]. */
+    fun record(
+        phase: FramePhase,
+        nanos: Long,
+    )
+
+    /** Snapshot the current p50/p95/max statistics for every phase. */
+    fun summary(): FrameProbeSummary
+
+    /** Drop all recorded samples. Used to discard warm-up before a measured run. */
+    fun reset()
+
+    /**
+     * The shared no-op probe. [isEnabled] is false, so [measure] never times
+     * anything and the other members do nothing.
+     */
+    object Disabled : FrameProbe {
+        override val isEnabled: Boolean = false
+
+        override fun record(
+            phase: FramePhase,
+            nanos: Long,
+        ) = Unit
+
+        override fun summary(): FrameProbeSummary = FrameProbeSummary(emptyMap())
+
+        override fun reset() = Unit
+    }
+}
+
+/**
+ * Time [block] as [phase] and return its result unchanged.
+ *
+ * Inlined so that when [FrameProbe.isEnabled] is false this is exactly `block()`
+ * behind one branch — zero added allocation. When enabled, the elapsed
+ * monotonic nanos are forwarded to [FrameProbe.record] even if [block] throws.
+ */
+inline fun <T> FrameProbe.measure(
+    phase: FramePhase,
+    block: () -> T,
+): T {
+    if (!isEnabled) return block()
+    val mark = TimeSource.Monotonic.markNow()
+    try {
+        return block()
+    } finally {
+        record(phase, mark.elapsedNow().inWholeNanoseconds)
+    }
+}

--- a/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/FrameProbeSummary.kt
+++ b/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/FrameProbeSummary.kt
@@ -1,0 +1,37 @@
+package link.socket.phosphor.lumos.probe
+
+/**
+ * Percentile statistics for a single [FramePhase], in nanoseconds.
+ *
+ * Percentiles use the nearest-rank method over the samples currently retained
+ * in the probe's ring buffer (at most its capacity). With an empty sample set
+ * every figure is zero and [sampleCount] is 0.
+ *
+ * @property phase The phase these statistics describe.
+ * @property sampleCount Number of samples the statistics were computed from.
+ * @property p50Nanos Median (50th percentile) duration.
+ * @property p95Nanos 95th percentile duration.
+ * @property maxNanos Largest retained sample.
+ */
+data class PhaseStats(
+    val phase: FramePhase,
+    val sampleCount: Int,
+    val p50Nanos: Long,
+    val p95Nanos: Long,
+    val maxNanos: Long,
+)
+
+/**
+ * A snapshot of [PhaseStats] per measured [FramePhase].
+ *
+ * Phases that have never recorded a sample are absent from [stats]; [forPhase]
+ * returns an empty (all-zero) [PhaseStats] for them so callers can render a
+ * full table without null checks.
+ */
+data class FrameProbeSummary(
+    val stats: Map<FramePhase, PhaseStats>,
+) {
+    /** Statistics for [phase], or an all-zero [PhaseStats] when none were recorded. */
+    fun forPhase(phase: FramePhase): PhaseStats =
+        stats[phase] ?: PhaseStats(phase, sampleCount = 0, p50Nanos = 0, p95Nanos = 0, maxNanos = 0)
+}

--- a/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/RingBufferFrameProbe.kt
+++ b/phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/RingBufferFrameProbe.kt
@@ -1,0 +1,96 @@
+package link.socket.phosphor.lumos.probe
+
+/**
+ * Enabled [FrameProbe] backed by a fixed-size ring buffer per phase.
+ *
+ * Each phase keeps the most recent [capacity] samples in a preallocated
+ * [LongArray]; [record] overwrites the oldest slot once full, so the hot path
+ * never allocates. Only [summary] allocates — it copies and sorts the retained
+ * samples — and it is intended to run off the frame loop (once, for reporting).
+ *
+ * Not thread-safe: drive it from the single render thread, matching the rest of
+ * the Lumos pipeline.
+ *
+ * @param capacity Samples retained per phase. Defaults to [DEFAULT_CAPACITY].
+ */
+class RingBufferFrameProbe(
+    val capacity: Int = DEFAULT_CAPACITY,
+) : FrameProbe {
+    init {
+        require(capacity > 0) { "capacity must be > 0, got $capacity" }
+    }
+
+    override val isEnabled: Boolean = true
+
+    // One ring per phase, indexed by FramePhase.ordinal. Preallocated; never resized.
+    private val rings: Array<LongArray> = Array(FramePhase.entries.size) { LongArray(capacity) }
+
+    // Monotonic count of records per phase. The live slice is the last
+    // min(written, capacity) entries; written % capacity is the next write slot.
+    private val written: LongArray = LongArray(FramePhase.entries.size)
+
+    override fun record(
+        phase: FramePhase,
+        nanos: Long,
+    ) {
+        val i = phase.ordinal
+        val count = written[i]
+        rings[i][(count % capacity).toInt()] = nanos
+        written[i] = count + 1
+    }
+
+    override fun summary(): FrameProbeSummary {
+        val stats = HashMap<FramePhase, PhaseStats>(FramePhase.entries.size)
+        for (phase in FramePhase.entries) {
+            val i = phase.ordinal
+            val size = minOf(written[i], capacity.toLong()).toInt()
+            if (size == 0) continue
+            stats[phase] = computeStats(phase, rings[i], size)
+        }
+        return FrameProbeSummary(stats)
+    }
+
+    override fun reset() {
+        written.fill(0L)
+    }
+
+    private fun computeStats(
+        phase: FramePhase,
+        ring: LongArray,
+        size: Int,
+    ): PhaseStats {
+        // Copy the live slice and sort ascending; ring order doesn't matter for percentiles.
+        val sorted = ring.copyOf(size)
+        sorted.sort()
+        return PhaseStats(
+            phase = phase,
+            sampleCount = size,
+            p50Nanos = percentile(sorted, 50),
+            p95Nanos = percentile(sorted, 95),
+            maxNanos = sorted[size - 1],
+        )
+    }
+
+    companion object {
+        /** Default retained samples per phase: 600 (~10s at 60fps, ~20s at 30fps). */
+        const val DEFAULT_CAPACITY: Int = 600
+
+        /**
+         * Nearest-rank percentile of an ascending-[sorted] array.
+         *
+         * For [percent] `p` and size `n`, returns the element at rank
+         * `ceil(p/100 * n)` (1-based), clamped to `[1, n]`. So `p95` of 600
+         * samples is `sorted[569]` and `p50` of an even count rounds up to the
+         * upper-middle element. Requires `sorted` non-empty.
+         */
+        internal fun percentile(
+            sorted: LongArray,
+            percent: Int,
+        ): Long {
+            val n = sorted.size
+            // ceil(percent * n / 100) without floating point.
+            val rank = ((percent.toLong() * n + 99) / 100).toInt().coerceIn(1, n)
+            return sorted[rank - 1]
+        }
+    }
+}

--- a/phosphor-lumos/src/commonTest/kotlin/link/socket/phosphor/lumos/probe/RingBufferFrameProbeTest.kt
+++ b/phosphor-lumos/src/commonTest/kotlin/link/socket/phosphor/lumos/probe/RingBufferFrameProbeTest.kt
@@ -1,0 +1,132 @@
+package link.socket.phosphor.lumos.probe
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RingBufferFrameProbeTest {
+    @Test
+    fun `summary math is correct on a full synthetic sequence`() {
+        val probe = RingBufferFrameProbe(capacity = 600)
+        // Record 1..600 ns; sorted order is identical to insertion order here.
+        for (n in 1..600) probe.record(FramePhase.BUILD, n.toLong())
+
+        val stats = probe.summary().forPhase(FramePhase.BUILD)
+        assertEquals(600, stats.sampleCount)
+        // Nearest-rank: p50 -> rank 300 -> value 300; p95 -> rank 570 -> value 570.
+        assertEquals(300L, stats.p50Nanos)
+        assertEquals(570L, stats.p95Nanos)
+        assertEquals(600L, stats.maxNanos)
+    }
+
+    @Test
+    fun `ring buffer wraps and retains only the most recent capacity samples`() {
+        val probe = RingBufferFrameProbe(capacity = 600)
+        // 900 records into a 600-slot ring: the first 300 are overwritten,
+        // leaving values 301..900.
+        for (n in 1..900) probe.record(FramePhase.PROJECT, n.toLong())
+
+        val stats = probe.summary().forPhase(FramePhase.PROJECT)
+        assertEquals(600, stats.sampleCount)
+        assertEquals(600L, stats.p50Nanos) // sorted[299] of 301..900
+        assertEquals(870L, stats.p95Nanos) // sorted[569] of 301..900
+        assertEquals(900L, stats.maxNanos)
+    }
+
+    @Test
+    fun `unsorted input still yields correct percentiles`() {
+        val probe = RingBufferFrameProbe(capacity = 8)
+        // Insert in scrambled order; percentiles must reflect sorted ranks.
+        listOf(40L, 10L, 30L, 20L).forEach { probe.record(FramePhase.DRAW, it) }
+
+        val stats = probe.summary().forPhase(FramePhase.DRAW)
+        assertEquals(4, stats.sampleCount)
+        assertEquals(20L, stats.p50Nanos) // rank 2 of [10,20,30,40]
+        assertEquals(40L, stats.p95Nanos) // rank 4
+        assertEquals(40L, stats.maxNanos)
+    }
+
+    @Test
+    fun `a single sample reports itself for every statistic`() {
+        val probe = RingBufferFrameProbe(capacity = 4)
+        probe.record(FramePhase.BUILD, 42L)
+
+        val stats = probe.summary().forPhase(FramePhase.BUILD)
+        assertEquals(1, stats.sampleCount)
+        assertEquals(42L, stats.p50Nanos)
+        assertEquals(42L, stats.p95Nanos)
+        assertEquals(42L, stats.maxNanos)
+    }
+
+    @Test
+    fun `phases accumulate independently`() {
+        val probe = RingBufferFrameProbe(capacity = 16)
+        probe.record(FramePhase.BUILD, 5L)
+        probe.record(FramePhase.BUILD, 7L)
+        probe.record(FramePhase.PROJECT, 100L)
+
+        val summary = probe.summary()
+        assertEquals(2, summary.forPhase(FramePhase.BUILD).sampleCount)
+        assertEquals(1, summary.forPhase(FramePhase.PROJECT).sampleCount)
+        // DRAW never recorded -> absent from the map, zeroed via forPhase.
+        assertNull(summary.stats[FramePhase.DRAW])
+        assertEquals(0, summary.forPhase(FramePhase.DRAW).sampleCount)
+        assertEquals(0L, summary.forPhase(FramePhase.DRAW).maxNanos)
+    }
+
+    @Test
+    fun `reset discards all samples`() {
+        val probe = RingBufferFrameProbe(capacity = 8)
+        repeat(8) { probe.record(FramePhase.DRAW, 1L) }
+        probe.reset()
+
+        assertTrue(probe.summary().stats.isEmpty())
+        // Reusable after reset.
+        probe.record(FramePhase.DRAW, 9L)
+        assertEquals(1, probe.summary().forPhase(FramePhase.DRAW).sampleCount)
+    }
+
+    @Test
+    fun `measure records one sample per call and returns the block result`() {
+        val probe = RingBufferFrameProbe(capacity = 4)
+        val result = probe.measure(FramePhase.BUILD) { 1 + 1 }
+        assertEquals(2, result)
+        assertEquals(1, probe.summary().forPhase(FramePhase.BUILD).sampleCount)
+    }
+
+    @Test
+    fun `measure records even when the block throws`() {
+        val probe = RingBufferFrameProbe(capacity = 4)
+        assertFailsWith<IllegalStateException> {
+            probe.measure(FramePhase.PROJECT) { error("boom") }
+        }
+        assertEquals(1, probe.summary().forPhase(FramePhase.PROJECT).sampleCount)
+    }
+
+    @Test
+    fun `disabled probe never records and returns the block result`() {
+        val probe = FrameProbe.Disabled
+        assertFalse(probe.isEnabled)
+        val result = probe.measure(FramePhase.DRAW) { "ok" }
+        assertEquals("ok", result)
+        assertTrue(probe.summary().stats.isEmpty())
+    }
+
+    @Test
+    fun `capacity must be positive`() {
+        assertFailsWith<IllegalArgumentException> { RingBufferFrameProbe(capacity = 0) }
+        assertFailsWith<IllegalArgumentException> { RingBufferFrameProbe(capacity = -1) }
+    }
+
+    @Test
+    fun `percentile nearest-rank boundaries`() {
+        val sorted = longArrayOf(10, 20, 30, 40, 50)
+        assertEquals(10L, RingBufferFrameProbe.percentile(sorted, 1))
+        assertEquals(30L, RingBufferFrameProbe.percentile(sorted, 50))
+        assertEquals(50L, RingBufferFrameProbe.percentile(sorted, 95))
+        assertEquals(50L, RingBufferFrameProbe.percentile(sorted, 100))
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a per-phase frame timing instrumentation system (`FrameProbe`) to measure the three distinct stages of the Lumos rendering pipeline: BUILD (voxel frame construction), PROJECT (2D projection), and DRAW (surface rendering). Includes a ring-buffer-backed enabled implementation and a no-op disabled singleton, plus a CLI baseline benchmark harness.

## Key Changes

- **New probe interfaces and types** (`phosphor-lumos/src/commonMain/kotlin/link/socket/phosphor/lumos/probe/`):
  - `FramePhase` enum: BUILD, PROJECT, DRAW phases
  - `FrameProbe` interface: contract for timing sinks with `measure()` inline function for zero-cost-when-disabled
  - `RingBufferFrameProbe`: enabled implementation using fixed-size ring buffers per phase, computing p50/p95/max percentiles on snapshot
  - `FrameProbeSummary` and `PhaseStats`: data classes for reporting statistics
  - Comprehensive test suite (`RingBufferFrameProbeTest`) covering ring wrapping, percentile math, phase independence, and edge cases

- **Integration into rendering pipeline**:
  - `VoxelFrameBuilder.build()`: wrapped with `probe.measure(FramePhase.BUILD, ...)`
  - `ComposeLattice.project()`: wrapped with `probe.measure(FramePhase.PROJECT, ...)`
  - `LumosCanvas` composable: wrapped DRAW operations with `probe.measure(FramePhase.DRAW, ...)`
  - `CliLattice.project()`: wrapped with `probe.measure(FramePhase.PROJECT, ...)`
  - `CliOrb.render()`: wrapped with `probe.measure(FramePhase.DRAW, ...)`

- **CLI baseline benchmark** (`phosphor-lumos-cli/src/jvmMain/kotlin/link/socket/phosphor/lumos/cli/bench/FrameProbeBenchmark.kt`):
  - Full-pipeline harness driving BUILD → PROJECT → DRAW for a configurable duration (default 60s)
  - Warm-up phase to stabilize JIT before measurement
  - Per-phase p50/p95/max reporting table
  - Zero-overhead-when-off validation: compares enabled vs. disabled probe overhead across multiple rounds
  - Terminal output sunk to discarding stream to measure ANSI assembly cost without flooding output
  - Gradle task: `./gradlew :phosphor-lumos-cli:runFrameProbeBenchmark` with optional duration parameter

## Implementation Details

- **Zero-cost-when-disabled**: The `measure()` function is `inline` and checks `isEnabled` at the top level, allowing the compiler to eliminate all timing code when using `FrameProbe.Disabled`
- **Ring buffer design**: Preallocated `LongArray` per phase, never resizes during recording; only allocates on `summary()` call (off-loop)
- **Percentile calculation**: Nearest-rank method (ceil-based) for consistent p50/p95 across different sample counts
- **Single-threaded contract**: Probe is not thread-safe; matches the pull-based, single-threaded nature of the Lumos pipeline
- **Graceful degradation**: Phases with no recorded samples return all-zero `PhaseStats` via `forPhase()` helper, enabling full-table rendering without null checks

https://claude.ai/code/session_011XB4x7uZbzBvaaLjk5faAV